### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/common/src/main/java/fi/otavanopisto/pyramus/util/ReflectionApiUtils.java
+++ b/common/src/main/java/fi/otavanopisto/pyramus/util/ReflectionApiUtils.java
@@ -8,6 +8,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ReflectionApiUtils {
 
+  private ReflectionApiUtils() {
+  }
+
   /**
    * Returns object field value using Java reflection API
    * 

--- a/common/src/main/java/fi/otavanopisto/pyramus/util/ThreadSessionContainer.java
+++ b/common/src/main/java/fi/otavanopisto/pyramus/util/ThreadSessionContainer.java
@@ -4,6 +4,9 @@ import javax.servlet.http.HttpSession;
 
 public class ThreadSessionContainer {
 
+  private ThreadSessionContainer() {
+  }
+
   public static HttpSession getSession() {
     return THREAD_LOCAL.get();
   }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
@@ -16,6 +16,9 @@ import fi.otavanopisto.pyramus.domainmodel.users.User;
 
 public class UserUtils {
 
+  private UserUtils() {
+  }
+
   /**
    * Is email address allowed (not in use)
    * 

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/persistence/events/TrackedEntityUtils.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/persistence/events/TrackedEntityUtils.java
@@ -12,6 +12,9 @@ import fi.otavanopisto.pyramus.domainmodel.changelog.TrackedEntityProperty;
 
 public class TrackedEntityUtils {
 
+  private TrackedEntityUtils() {
+  }
+
   public synchronized static boolean isTrackedEntity(String entityName) {
     return getTrackedEntityMap().get(entityName) != null;
   }

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/utils/EncodingUtils.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/utils/EncodingUtils.java
@@ -11,6 +11,9 @@ import org.apache.commons.lang.StringUtils;
  */
 public class EncodingUtils {
 
+  private EncodingUtils() {
+  }
+
   /** Calculate the MD5 sum of a string.
    * 
    * @param s The string to encode.

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/ReportUtils.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/ReportUtils.java
@@ -5,7 +5,10 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 
 public class ReportUtils {
-  
+
+  private ReportUtils() {
+  }
+
   public static String getReportsUrl(HttpServletRequest request) {
     String contextPath = System.getProperty("reports.contextPath");
     String host = System.getProperty("reports.host");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportUtils.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportUtils.java
@@ -24,6 +24,9 @@ import fi.otavanopisto.pyramus.persistence.usertypes.MonetaryAmount;
 
 public class DataImportUtils {
 
+  private DataImportUtils() {
+  }
+
   /**
    * 
    * @param pojo

--- a/smvcj/src/main/java/fi/internetix/smvc/controllers/RequestControllerMapper.java
+++ b/smvcj/src/main/java/fi/internetix/smvc/controllers/RequestControllerMapper.java
@@ -9,6 +9,9 @@ import fi.internetix.smvc.logging.Logging;
 
 public class RequestControllerMapper {
 
+  private RequestControllerMapper() {
+  }
+
   public static RequestController getRequestController(String controllerName) {
     return requestControllers.get(controllerName);
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.