### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/common/src/main/java/fi/otavanopisto/pyramus/util/ThreadSessionContainer.java
+++ b/common/src/main/java/fi/otavanopisto/pyramus/util/ThreadSessionContainer.java
@@ -12,5 +12,5 @@ public class ThreadSessionContainer {
     THREAD_LOCAL.set(httpSession);
   }
   
-  private static final ThreadLocal<HttpSession> THREAD_LOCAL = new ThreadLocal<HttpSession>();
+  private static final ThreadLocal<HttpSession> THREAD_LOCAL = new ThreadLocal<>();
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/PyramusViewController.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/PyramusViewController.java
@@ -116,7 +116,7 @@ public abstract class PyramusViewController implements PageController {
     @SuppressWarnings("unchecked")
     Map<String, String> jsData = (Map<String, String>) pageRequestContext.getRequest().getAttribute("jsData");
     if (jsData == null) {
-      jsData = new HashMap<String, String>();
+      jsData = new HashMap<>();
       pageRequestContext.getRequest().setAttribute("jsData", jsData);
     }
     

--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
@@ -73,7 +73,7 @@ public class UserUtils {
       return allowed;
     } else {
       // True, if email is not in use
-      return (staffMember == null) && (students.isEmpty());
+      return staffMember == null && students.isEmpty();
     }
   }
   

--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
@@ -91,7 +91,7 @@ public class UserUtils {
   }
   
   public static List<Role> getRoleOrder() {
-    List<Role> list = new ArrayList<Role>();
+    List<Role> list = new ArrayList<>();
 
     list.add(Role.ADMINISTRATOR);
     list.add(Role.MANAGER);

--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
@@ -73,7 +73,7 @@ public class UserUtils {
       return allowed;
     } else {
       // True, if email is not in use
-      return (staffMember == null) && (students.size() == 0);
+      return (staffMember == null) && (students.isEmpty());
     }
   }
   

--- a/framework/src/main/java/fi/otavanopisto/pyramus/security/impl/StudentOwnerPermissionResolver.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/security/impl/StudentOwnerPermissionResolver.java
@@ -40,7 +40,7 @@ public class StudentOwnerPermissionResolver extends AbstractPermissionResolver i
 //        " @ " + 
 //        contextReference);
     
-    if ((user1 != null) && (user2 != null)) {
+    if (user1 != null && user2 != null) {
       // Users must match
       if (user1.getId().equals(user2.getId())) {
         if (Student.class.isInstance(user2)) {

--- a/framework/src/main/java/fi/otavanopisto/pyramus/security/impl/UserOwnerPermissionResolver.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/security/impl/UserOwnerPermissionResolver.java
@@ -29,7 +29,7 @@ public class UserOwnerPermissionResolver extends AbstractPermissionResolver impl
   public boolean hasPermission(String permission, ContextReference contextReference, User user) {
     fi.otavanopisto.pyramus.domainmodel.users.User user1 = getUser(user);
     fi.otavanopisto.pyramus.domainmodel.users.User user2 = resolveUser(contextReference);
-    if ((user1 != null) && (user2 != null)) {
+    if (user1 != null && user2 != null) {
       // The underlying persons of the users must match
       return user1.getPerson().getId().equals(user2.getPerson().getId());
     }

--- a/googleoauth-plugin/src/main/java/fi/otavanopisto/pyramus/plugin/googleoauth/GoogleOauthPluginDescriptor.java
+++ b/googleoauth-plugin/src/main/java/fi/otavanopisto/pyramus/plugin/googleoauth/GoogleOauthPluginDescriptor.java
@@ -28,7 +28,7 @@ public class GoogleOauthPluginDescriptor implements PluginDescriptor {
   }
   
   public Map<String, Class<?>> getAuthenticationProviders() {
-    Map<String, Class<?>> authenticationProviders = new HashMap<String, Class<?>>();
+    Map<String, Class<?>> authenticationProviders = new HashMap<>();
     
     authenticationProviders.put(this.getName(), GoogleOauthAuthorizationStrategy.class);
     

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/GenericDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/GenericDAO.java
@@ -96,7 +96,7 @@ public abstract class GenericDAO<T> {
     @SuppressWarnings("unchecked")
     List<T> list = query.getResultList();
     
-    if (list.size() == 0)
+    if (list.isEmpty())
       return null;
     
     if (list.size() == 1)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/SystemDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/SystemDAO.java
@@ -51,7 +51,7 @@ public class SystemDAO {
   }
   
   public Set<javax.persistence.metamodel.Attribute<?, ?>> getEntityAttributes(Class<?> entityClass) {
-    Set<javax.persistence.metamodel.Attribute<?, ?>> result = new HashSet<javax.persistence.metamodel.Attribute<?,?>>();
+    Set<javax.persistence.metamodel.Attribute<?, ?>> result = new HashSet<>();
     
     EntityType<?> entityType = getEntityManager().getMetamodel().entity(entityClass);
     for (javax.persistence.metamodel.Attribute<?, ?> attribute : entityType.getAttributes()) {
@@ -77,7 +77,7 @@ public class SystemDAO {
   // Hibernate search methods
  
   public List<Class<?>> getIndexedEntities() {
-    List<Class<?>> result = new ArrayList<Class<?>>();
+    List<Class<?>> result = new ArrayList<>();
     
     EntityManager entityManager = getEntityManager();
     Metamodel metamodel = entityManager.getEntityManagerFactory().getMetamodel();

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/base/PersonDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/base/PersonDAO.java
@@ -250,7 +250,7 @@ public class PersonDAO extends PyramusEntityDAO<Person> {
     List<Long> studentIds = null;
     
     if (studentGroup != null) {
-      studentIds = new ArrayList<Long>();
+      studentIds = new ArrayList<>();
       
       switch (studentFilter) {
         case ALL:
@@ -305,7 +305,7 @@ public class PersonDAO extends PyramusEntityDAO<Person> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Person>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     } catch (ParseException e) {
       throw new PersistenceException(e);
     }
@@ -520,7 +520,7 @@ public class PersonDAO extends PyramusEntityDAO<Person> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Person>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     } catch (ParseException e) {
       throw new PersistenceException(e);
     }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/base/SchoolDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/base/SchoolDAO.java
@@ -128,7 +128,7 @@ public class SchoolDAO extends PyramusEntityDAO<School> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<School>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);
@@ -198,7 +198,7 @@ public class SchoolDAO extends PyramusEntityDAO<School> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<School>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/base/SubjectDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/base/SubjectDAO.java
@@ -144,7 +144,7 @@ public class SubjectDAO extends PyramusEntityDAO<Subject> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Subject>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/courses/CourseDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/courses/CourseDAO.java
@@ -356,7 +356,7 @@ public class CourseDAO extends PyramusEntityDAO<Course> {
     if (educationSubtype != null)
       addTokenizedSearchCriteria(queryBuilder, "courseEducationTypes.courseEducationSubtypes.educationSubtype.id", educationSubtype.getId().toString(), true);
     
-    if ((timeframeS != null) && (timeframeE != null)) {
+    if (timeframeS != null && timeframeE != null) {
       switch (timeFilterMode) {
       case EXCLUSIVE:
         /** beginDate > timeframeStart and endDate < timeframeEnd **/

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/courses/CourseDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/courses/CourseDAO.java
@@ -296,7 +296,7 @@ public class CourseDAO extends PyramusEntityDAO<Course> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Course>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     }
     catch (ParseException e) {
       throw new PersistenceException(e);
@@ -439,7 +439,7 @@ public class CourseDAO extends PyramusEntityDAO<Course> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Course>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     }
     catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/courses/CourseStudentDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/courses/CourseStudentDAO.java
@@ -238,7 +238,7 @@ public class CourseStudentDAO extends PyramusEntityDAO<CourseStudent> {
   }
 
   public List<CourseStudent> listByCourseAndParticipationTypesIncludeArchived(Course course, List<CourseParticipationType> participationTypes) {
-    if ((participationTypes == null) || (participationTypes.isEmpty())) {
+    if (participationTypes == null || participationTypes.isEmpty()) {
       return Collections.emptyList();
     }
     

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/TransferCreditTemplateCourseDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/TransferCreditTemplateCourseDAO.java
@@ -70,7 +70,7 @@ public class TransferCreditTemplateCourseDAO extends PyramusEntityDAO<TransferCr
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<TransferCreditTemplateCourse>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/help/HelpPageDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/help/HelpPageDAO.java
@@ -70,7 +70,7 @@ public class HelpPageDAO extends PyramusEntityDAO<HelpPage> {
   
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
   
-      return new SearchResult<HelpPage>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     } catch (ParseException e) {
       throw new PersistenceException(e);
     }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/modules/ModuleDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/modules/ModuleDAO.java
@@ -188,7 +188,7 @@ public class ModuleDAO extends PyramusEntityDAO<Module> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Module>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     } catch (ParseException e) {
       throw new PersistenceException(e);
     }
@@ -251,7 +251,7 @@ public class ModuleDAO extends PyramusEntityDAO<Module> {
     // If project text is given, only include modules that are in project(s) having the given name
     // (only the first ten matching projects, though, to prevent the search from becoming too gigantic...)
 
-    Set<Long> moduleIds = new HashSet<Long>();
+    Set<Long> moduleIds = new HashSet<>();
     if (!StringUtils.isBlank(projectName)) {
       ProjectDAO projectDAO = DAOFactory.getInstance().getProjectDAO();
       SearchResult<Project> searchResults = projectDAO.searchProjectsBasic(10, 0, projectName);
@@ -270,7 +270,7 @@ public class ModuleDAO extends PyramusEntityDAO<Module> {
         queryBuilder.append(")");
       } else {
         // Search condition by project name didn't yield any projects, so there cannot be any results
-        return new SearchResult<Module>(0, 0, 0, 0, 0, new ArrayList<Module>());
+        return new SearchResult<>(0, 0, 0, 0, 0, new ArrayList<Module>());
       }
     }
 
@@ -307,7 +307,7 @@ public class ModuleDAO extends PyramusEntityDAO<Module> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Module>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/projects/ProjectDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/projects/ProjectDAO.java
@@ -121,7 +121,7 @@ public class ProjectDAO extends PyramusEntityDAO<Project> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Project>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     }
     catch (ParseException e) {
@@ -192,7 +192,7 @@ public class ProjectDAO extends PyramusEntityDAO<Project> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<Project>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/projects/StudentProjectDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/projects/StudentProjectDAO.java
@@ -152,7 +152,7 @@ public class StudentProjectDAO extends PyramusEntityDAO<StudentProject> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<StudentProject>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     }
     catch (ParseException e) {
@@ -207,7 +207,7 @@ public class StudentProjectDAO extends PyramusEntityDAO<StudentProject> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<StudentProject>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     }
     catch (ParseException e) {

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/resources/ResourceDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/resources/ResourceDAO.java
@@ -79,7 +79,7 @@ public class ResourceDAO extends PyramusEntityDAO<Resource> {
         lastResult = hits - 1;
       }
 
-      return new SearchResult<Resource>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     } catch (ParseException e) {
       throw new PersistenceException(e);
     }
@@ -165,7 +165,7 @@ public class ResourceDAO extends PyramusEntityDAO<Resource> {
         lastResult = hits - 1;
       }
 
-      return new SearchResult<Resource>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     } catch (ParseException e) {
       throw new PersistenceException(e);
     }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/students/StudentDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/students/StudentDAO.java
@@ -79,7 +79,7 @@ public class StudentDAO extends PyramusEntityDAO<Student> {
       // Also archive course students of the archived student
       
       List<CourseStudent> courseStudents = courseStudentDAO.listByStudent(student);
-      if (courseStudents.size() > 0) {
+      if (!courseStudents.isEmpty()) {
         for (CourseStudent courseStudent : courseStudents) {
           courseStudentDAO.archive(courseStudent);
         }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/students/StudentGroupDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/students/StudentGroupDAO.java
@@ -203,7 +203,7 @@ public class StudentGroupDAO extends PyramusEntityDAO<StudentGroup> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<StudentGroup>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     }
     catch (ParseException e) {
       throw new PersistenceException(e);
@@ -254,7 +254,7 @@ public class StudentGroupDAO extends PyramusEntityDAO<StudentGroup> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<StudentGroup>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
     }
     catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/students/StudentGroupDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/students/StudentGroupDAO.java
@@ -153,7 +153,7 @@ public class StudentGroupDAO extends PyramusEntityDAO<StudentGroup> {
       addTokenizedSearchCriteria(queryBuilder, "users.user.id", user.getId().toString(), true);
     }
     
-    if ((timeframeS != null) && (timeframeE != null)) {
+    if (timeframeS != null && timeframeE != null) {
       /**
        * (beginDate between timeframeStart - timeframeEnd or endDate between timeframeStart -
        * timeframeEnd) or (startDate less than timeframeStart and endDate more than

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/users/StaffMemberDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/users/StaffMemberDAO.java
@@ -241,7 +241,7 @@ public class StaffMemberDAO extends PyramusEntityDAO<StaffMember> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<StaffMember>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);
@@ -311,7 +311,7 @@ public class StaffMemberDAO extends PyramusEntityDAO<StaffMember> {
 
       int lastResult = Math.min(firstResult + resultsPerPage, hits) - 1;
 
-      return new SearchResult<StaffMember>(page, pages, hits, firstResult, lastResult, query.getResultList());
+      return new SearchResult<>(page, pages, hits, firstResult, lastResult, query.getResultList());
 
     } catch (ParseException e) {
       throw new PersistenceException(e);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/ContactInfo.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/ContactInfo.java
@@ -145,25 +145,25 @@ public class ContactInfo {
   @OrderColumn (name = "indexColumn")
   @JoinColumn (name="contactInfo")
   @IndexedEmbedded
-  private List<Address> addresses = new Vector<Address>();
+  private List<Address> addresses = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderColumn (name = "indexColumn")
   @JoinColumn (name="contactInfo")
   @IndexedEmbedded
-  private List<Email> emails = new Vector<Email>();
+  private List<Email> emails = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderColumn (name = "indexColumn")
   @JoinColumn (name="contactInfo")
   @IndexedEmbedded
-  private List<PhoneNumber> phoneNumbers = new Vector<PhoneNumber>();
+  private List<PhoneNumber> phoneNumbers = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderColumn (name = "indexColumn")
   @JoinColumn (name="contactInfo")
   @IndexedEmbedded
-  private List<ContactURL> contactURLs = new Vector<ContactURL>();
+  private List<ContactURL> contactURLs = new Vector<>();
 
   @Lob  
   @Basic (fetch = FetchType.LAZY)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
@@ -376,7 +376,7 @@ public abstract class CourseBase implements ArchivableEntity {
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="courseBase")
   @IndexedEmbedded
-  private List<CourseEducationType> courseEducationTypes = new Vector<CourseEducationType>();
+  private List<CourseEducationType> courseEducationTypes = new Vector<>();
 
   @NotNull
   @Column(nullable = false)
@@ -385,7 +385,7 @@ public abstract class CourseBase implements ArchivableEntity {
   
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="courseBase")
-  private List<CourseBaseVariable> variables = new ArrayList<CourseBaseVariable>();
+  private List<CourseBaseVariable> variables = new ArrayList<>();
 
   @Column
   private Long maxParticipantCount;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseEducationType.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseEducationType.java
@@ -165,7 +165,7 @@ public class CourseEducationType {
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "courseEducationType")
   @IndexedEmbedded
-  private List<CourseEducationSubtype> courseEducationSubtypes = new Vector<CourseEducationSubtype>();
+  private List<CourseEducationSubtype> courseEducationSubtypes = new Vector<>();
 
   @Version
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
@@ -245,7 +245,7 @@ public class Person implements ContextReference {
 
   private StaffMember getStaffMember() {
     List<StaffMember> staffMembers = getStaffMembers();
-    return staffMembers.size() > 0 ? staffMembers.get(0) : null;
+    return !staffMembers.isEmpty() ? staffMembers.get(0) : null;
   }
 
   @Transient

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
@@ -135,7 +135,7 @@ public class Person implements ContextReference {
 
   public List<StaffMember> getStaffMembers() {
     List<User> users = getUsers();
-    List<StaffMember> staffMembers = new ArrayList<StaffMember>();
+    List<StaffMember> staffMembers = new ArrayList<>();
     
     for (User user : users) {
       if (user instanceof StaffMember)
@@ -147,7 +147,7 @@ public class Person implements ContextReference {
   
   public List<Student> getStudents() {
     List<User> users = getUsers();
-    List<Student> students = new ArrayList<Student>();
+    List<Student> students = new ArrayList<>();
     
     for (User user : users) {
       if (user instanceof Student)
@@ -178,7 +178,7 @@ public class Person implements ContextReference {
 
   @Transient
   public Student getLatestStudent() {
-    List<Student> students = new ArrayList<Student>();
+    List<Student> students = new ArrayList<>();
     
     if (this.getUsers() != null) {
       for (Student student : this.getStudents()) {
@@ -267,7 +267,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveFirstNames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getFirstName() != null) {
@@ -281,7 +281,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveLastNames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getLastName() != null) {
@@ -295,7 +295,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveNicknames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getNickname() != null) {
@@ -309,7 +309,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveEducations() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getEducation() != null) {
@@ -324,7 +324,7 @@ public class Person implements ContextReference {
   @Field(analyze = Analyze.NO)
   @FieldBridge(impl = CollectionBridge.class)
   public Set<String> getInactiveEmails() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (Email email : student.getContactInfo().getEmails()) {
@@ -341,7 +341,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveStreetAddresses() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -357,7 +357,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactivePostalCodes() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -392,7 +392,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveCities() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -408,7 +408,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveCountries() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -424,7 +424,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactivePhones() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (PhoneNumber phoneNumber : student.getContactInfo().getPhoneNumbers()) {
@@ -438,7 +438,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveLodgings() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getLodging() != null) {
@@ -452,7 +452,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveStudyProgrammeIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getStudyProgramme() != null)
@@ -465,7 +465,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveLanguageIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getLanguage() != null)
@@ -478,7 +478,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveMunicipalityIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getMunicipality() != null)
@@ -491,7 +491,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveNationalityIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         if (student.getNationality() != null)
@@ -504,7 +504,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveFirstNames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getFirstName() != null) {
@@ -519,7 +519,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveLastNames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getLastName() != null) {
@@ -534,7 +534,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveNicknames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getNickname() != null) {
@@ -548,7 +548,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveEducations() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getEducation() != null) {
@@ -563,7 +563,7 @@ public class Person implements ContextReference {
   @Field(analyze = Analyze.NO)
   @FieldBridge(impl = CollectionBridge.class)
   public Set<String> getActiveEmails() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (Email email : student.getContactInfo().getEmails()) {
@@ -580,7 +580,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveStreetAddresses() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -596,7 +596,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActivePostalCodes() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -640,7 +640,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveCities() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -657,7 +657,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveCountries() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (Address address : student.getContactInfo().getAddresses()) {
@@ -674,7 +674,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActivePhones() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (PhoneNumber phoneNumber : student.getContactInfo().getPhoneNumbers()) {
@@ -688,7 +688,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveLodgings() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getLodging() != null) {
@@ -702,7 +702,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveStudyProgrammeIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getStudyProgramme() != null)
@@ -715,7 +715,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveLanguageIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getLanguage() != null)
@@ -728,7 +728,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveMunicipalityIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getMunicipality() != null)
@@ -741,7 +741,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveNationalityIds() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         if (student.getNationality() != null)
@@ -754,7 +754,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getActiveTags() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && student.getActive()) {
         for (Tag tag : student.getTags()) {
@@ -775,7 +775,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getInactiveTags() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (Student student : getStudents()) {
       if (!student.getArchived() && !student.getActive()) {
         for (Tag tag : student.getTags()) {
@@ -790,7 +790,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberFirstNames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       String s = staffMember.getFirstName(); 
       
@@ -805,7 +805,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberLastNames() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       String s = staffMember.getLastName(); 
       
@@ -821,7 +821,7 @@ public class Person implements ContextReference {
   @Field(analyze = Analyze.NO)
   @FieldBridge(impl = CollectionBridge.class)
   public Set<String> getStaffMemberEmails() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       
       for (Email email : staffMember.getContactInfo().getEmails()) {
@@ -839,7 +839,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberTitles() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       String s = staffMember.getTitle(); 
       
@@ -854,7 +854,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberRoles() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       String s = staffMember.getRole().toString(); 
       
@@ -869,7 +869,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberTags() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       for (Tag tag : staffMember.getTags()) {
         String s = tag.getText();
@@ -886,7 +886,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberPhones() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       for (PhoneNumber number : staffMember.getContactInfo().getPhoneNumbers()) {
         String s = number.getNumber(); 
@@ -903,7 +903,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberStreetAddresses() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       for (Address address : staffMember.getContactInfo().getAddresses()) {
         String s = address.getStreetAddress(); 
@@ -920,7 +920,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberPostalCodes() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       for (Address address : staffMember.getContactInfo().getAddresses()) {
         String s = address.getPostalCode(); 
@@ -937,7 +937,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberCities() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       for (Address address : staffMember.getContactInfo().getAddresses()) {
         String s = address.getCity(); 
@@ -954,7 +954,7 @@ public class Person implements ContextReference {
   @Transient
   @Field
   public String getStaffMemberCountries() {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (StaffMember staffMember : getStaffMembers()) {
       for (Address address : staffMember.getContactInfo().getAddresses()) {
         String s = address.getCountry(); 
@@ -1041,7 +1041,7 @@ public class Person implements ContextReference {
   @OneToMany
   @JoinColumn(name = "person_id")
   @IndexedEmbedded
-  private List<User> users = new ArrayList<User>();
+  private List<User> users = new ArrayList<>();
   
   @OneToOne
   private User defaultUser;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
@@ -204,7 +204,7 @@ public class Person implements ContextReference {
           if (o1Value == o2Value) {
             Date o1StudyStart = o1.getStudyStartDate();
             Date o2StudyStart = o2.getStudyStartDate(); 
-            return (o1StudyStart != null) && (o2StudyStart != null) ? o2StudyStart.compareTo(o1StudyStart) : 0;
+            return o1StudyStart != null && o2StudyStart != null ? o2StudyStart.compareTo(o1StudyStart) : 0;
           }
           
           return o1Value < o2Value ? -1 : 1;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/School.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/School.java
@@ -185,7 +185,7 @@ public class School implements ArchivableEntity {
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__SchoolTags", joinColumns=@JoinColumn(name="school"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
 
   @ManyToOne
   @JoinColumn (name = "field")

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/Course.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/Course.java
@@ -318,28 +318,28 @@ public class Course extends CourseBase implements ArchivableEntity, ContextRefer
   @IndexColumn (name = "indexColumn")
   @JoinColumn (name="course")
   @IndexedEmbedded
-  private List<CourseComponent> courseComponents = new Vector<CourseComponent>();
+  private List<CourseComponent> courseComponents = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="course")
-  private List<BasicCourseResource> basicCourseResources = new Vector<BasicCourseResource>();
+  private List<BasicCourseResource> basicCourseResources = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="course")
-  private List<StudentCourseResource> studentCourseResources = new Vector<StudentCourseResource>();
+  private List<StudentCourseResource> studentCourseResources = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="course")
-  private List<GradeCourseResource> gradeCourseResources = new Vector<GradeCourseResource>();
+  private List<GradeCourseResource> gradeCourseResources = new Vector<>();
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="course")
-  private List<OtherCost> otherCosts = new Vector<OtherCost>();
+  private List<OtherCost> otherCosts = new Vector<>();
 
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__CourseTags", joinColumns=@JoinColumn(name="course"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
   
   @Column
   @Temporal (value=TemporalType.TIMESTAMP)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/CourseComponent.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/CourseComponent.java
@@ -61,5 +61,5 @@ public class CourseComponent extends ComponentBase {
 
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="courseComponent")
-  private List<CourseComponentResource> resources = new ArrayList<CourseComponentResource>();
+  private List<CourseComponentResource> resources = new ArrayList<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/GradingScale.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/GradingScale.java
@@ -105,7 +105,7 @@ public class GradingScale implements ArchivableEntity {
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @IndexColumn (name = "indexColumn")
   @JoinColumn (name="gradingScale")
-  private List<Grade> grades = new ArrayList<Grade>(); 
+  private List<Grade> grades = new ArrayList<>(); 
 
   @Version
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/TransferCreditTemplate.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/TransferCreditTemplate.java
@@ -88,5 +88,5 @@ public class TransferCreditTemplate {
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @IndexColumn (name = "indexColumn")
   @JoinColumn (name="transferCreditTemplate")
-  private List<TransferCreditTemplateCourse> courses = new ArrayList<TransferCreditTemplateCourse>();
+  private List<TransferCreditTemplateCourse> courses = new ArrayList<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpFolder.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpFolder.java
@@ -41,5 +41,5 @@ public class HelpFolder extends HelpItem {
   }
   
   @OneToMany (cascade = CascadeType.ALL, mappedBy="parent")
-  private List<HelpItem> children = new ArrayList<HelpItem>();
+  private List<HelpItem> children = new ArrayList<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpItem.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpItem.java
@@ -217,10 +217,10 @@ public class HelpItem {
   
   @OneToMany (cascade = CascadeType.ALL, mappedBy="item")
   @IndexedEmbedded
-  private List<HelpItemTitle> titles = new ArrayList<HelpItemTitle>();
+  private List<HelpItemTitle> titles = new ArrayList<>();
   
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__HelpItemTags", joinColumns=@JoinColumn(name="helpItem"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
 } 

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpPage.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpPage.java
@@ -54,5 +54,5 @@ public class HelpPage extends HelpItem {
   
   @OneToMany (cascade = CascadeType.ALL, mappedBy="page")
   @IndexedEmbedded
-  private List<HelpPageContent> contents = new ArrayList<HelpPageContent>();
+  private List<HelpPageContent> contents = new ArrayList<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/modules/Module.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/modules/Module.java
@@ -86,10 +86,10 @@ public class Module extends CourseBase implements ArchivableEntity {
   @IndexColumn (name = "indexColumn")
   @JoinColumn (name="module")
   @IndexedEmbedded
-  private List<ModuleComponent> moduleComponents = new Vector<ModuleComponent>();
+  private List<ModuleComponent> moduleComponents = new Vector<>();
 
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__ModuleTags", joinColumns=@JoinColumn(name="module"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/Project.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/Project.java
@@ -287,7 +287,7 @@ public class Project implements ArchivableEntity {
   @IndexColumn (name = "indexColumn")
   @JoinColumn (name="project")
   @IndexedEmbedded
-  private List<ProjectModule> projectModules = new Vector<ProjectModule>();
+  private List<ProjectModule> projectModules = new Vector<>();
 
   @ManyToOne
   @JoinColumn(name="creator")
@@ -314,7 +314,7 @@ public class Project implements ArchivableEntity {
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__ProjectTags", joinColumns=@JoinColumn(name="project"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
   
   @Version
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/StudentProject.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/StudentProject.java
@@ -330,7 +330,7 @@ public class StudentProject implements ArchivableEntity {
   @IndexColumn (name = "indexColumn")
   @JoinColumn (name="studentProject")
   @IndexedEmbedded 
-  private List<StudentProjectModule> studentProjectModules = new Vector<StudentProjectModule>();
+  private List<StudentProjectModule> studentProjectModules = new Vector<>();
 
   @ManyToOne 
   @JoinColumn(name="creator")
@@ -357,7 +357,7 @@ public class StudentProject implements ArchivableEntity {
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__StudentProjectTags", joinColumns=@JoinColumn(name="studentProject"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
   
   @ManyToOne
   @JoinColumn(name="project")

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/resources/Resource.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/resources/Resource.java
@@ -159,7 +159,7 @@ public class Resource implements ArchivableEntity {
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__ResourceTags", joinColumns=@JoinColumn(name="resource"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
   
   @Version
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/Student.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/Student.java
@@ -206,7 +206,7 @@ public class Student extends User implements ArchivableEntity {
 	
 	@Transient
 	public boolean getActive() {
-	  return getHasStartedStudies() && (!getHasFinishedStudies());
+	  return getHasStartedStudies() && !getHasFinishedStudies();
 	}
 
   @Transient

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroup.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroup.java
@@ -265,16 +265,16 @@ public class StudentGroup implements ArchivableEntity {
   @OneToMany
   @JoinColumn (name="studentGroup")
   @IndexedEmbedded
-  private Set<StudentGroupUser> users = new HashSet<StudentGroupUser>();
+  private Set<StudentGroupUser> users = new HashSet<>();
   
   @OneToMany
   @JoinColumn (name="studentGroup")
-  private Set<StudentGroupStudent> students = new HashSet<StudentGroupStudent>();
+  private Set<StudentGroupStudent> students = new HashSet<>();
 
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__StudentGroupTags", joinColumns=@JoinColumn(name="studentGroup"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
   
   @Version
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentStudyEndReason.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentStudyEndReason.java
@@ -89,7 +89,7 @@ public class StudentStudyEndReason {
 
   @OneToMany
   @JoinColumn (name = "parentReason")
-  private List<StudentStudyEndReason> childEndReasons = new ArrayList<StudentStudyEndReason>();
+  private List<StudentStudyEndReason> childEndReasons = new ArrayList<>();
 
   @Version
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/User.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/User.java
@@ -198,12 +198,12 @@ public class User implements fi.otavanopisto.security.User, ContextReference {
   @ManyToMany (fetch = FetchType.LAZY)
   @JoinTable (name="__UserBillingDetails", joinColumns=@JoinColumn(name="user"), inverseJoinColumns=@JoinColumn(name="billingDetails"))
   @IndexedEmbedded 
-  private List<BillingDetails> billingDetails = new ArrayList<BillingDetails>();
+  private List<BillingDetails> billingDetails = new ArrayList<>();
 
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name="__UserTags", joinColumns=@JoinColumn(name="user"), inverseJoinColumns=@JoinColumn(name="tag"))
   @IndexedEmbedded 
-  private Set<Tag> tags = new HashSet<Tag>();
+  private Set<Tag> tags = new HashSet<>();
   
   @NotNull
   @Column (nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/persistence/events/EntityStateData.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/persistence/events/EntityStateData.java
@@ -7,11 +7,11 @@ import java.util.Map;
 public class EntityStateData {
 
   public Map<String, Object> addUpdateBatch(String entity, Object id) {
-    Map<String, Object> updateBatch = new HashMap<String, Object>();
+    Map<String, Object> updateBatch = new HashMap<>();
 
     Map<Object, Map<String, Object>> entityUpdateBatch = updateBatches.get(entity);
     if (entityUpdateBatch == null) {
-      entityUpdateBatch = new HashMap<Object, Map<String, Object>>();
+      entityUpdateBatch = new HashMap<>();
       updateBatches.put(entity, entityUpdateBatch);
     }
     
@@ -31,5 +31,5 @@ public class EntityStateData {
     entityUpdateBatch.remove(id);
   }
 
-  private Map<String, Map<Object, Map<String, Object>>> updateBatches = new Hashtable<String, Map<Object, Map<String, Object>>>();
+  private Map<String, Map<Object, Map<String, Object>>> updateBatches = new Hashtable<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/persistence/events/TrackedEntityUtils.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/persistence/events/TrackedEntityUtils.java
@@ -23,7 +23,7 @@ public class TrackedEntityUtils {
   
   private synchronized static Map<String, Set<String>> getTrackedEntityMap() {
     if (trackedEntities == null) {
-      trackedEntities = new HashMap<String, Set<String>>();
+      trackedEntities = new HashMap<>();
       TrackedEntityPropertyDAO trackedEntityPropertyDAO = DAOFactory.getInstance().getTrackedEntityPropertyDAO();
       List<TrackedEntityProperty> trackedEntityProperties = trackedEntityPropertyDAO.listAll();
       for (TrackedEntityProperty trackedEntityProperty : trackedEntityProperties) {
@@ -32,7 +32,7 @@ public class TrackedEntityUtils {
         
         Set<String> properties = trackedEntities.get(entity);
         if (properties == null) {
-          properties = new HashSet<String>();
+          properties = new HashSet<>();
           trackedEntities.put(entity, properties);
         }
         

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/PageHookVault.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/PageHookVault.java
@@ -31,7 +31,7 @@ public class PageHookVault {
     List<PageHookController> hooks = pageHooks.get(hookName);
     
     if (hooks == null) {
-      hooks = new ArrayList<PageHookController>();
+      hooks = new ArrayList<>();
       pageHooks.put(hookName, hooks);
     }
     
@@ -44,7 +44,7 @@ public class PageHookVault {
     }
   }
   
-  private Map<String, List<PageHookController>> pageHooks = new HashMap<String, List<PageHookController>>();
+  private Map<String, List<PageHookController>> pageHooks = new HashMap<>();
 
   static {
     List<PluginDescriptor> plugins = PluginManager.getInstance().getPlugins();

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/PluginManager.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/PluginManager.java
@@ -210,7 +210,7 @@ public class PluginManager {
   }
 
   public List<ScheduledPluginTask> getScheduledTasks(ScheduledTaskInterval internal) {
-    List<ScheduledPluginTask> result = new ArrayList<ScheduledPluginTask>();
+    List<ScheduledPluginTask> result = new ArrayList<>();
     
     for (ScheduledPluginDescriptor sceduledPlugin : getScheduledPlugins()) {
       List<ScheduledPluginTask> tasks = sceduledPlugin.getScheduledTasks();
@@ -227,7 +227,7 @@ public class PluginManager {
   }
   
   public List<ScheduledPluginDescriptor> getScheduledPlugins() {
-    List<ScheduledPluginDescriptor> result = new ArrayList<ScheduledPluginDescriptor>();
+    List<ScheduledPluginDescriptor> result = new ArrayList<>();
     
     for (PluginDescriptor plugin : getPlugins()) {
       if (plugin instanceof ScheduledPluginDescriptor) {
@@ -239,7 +239,7 @@ public class PluginManager {
   }
   
   public List<CustomLoginScreenPlugin> getCustomLoginScreenPlugins() {
-    List<CustomLoginScreenPlugin> result = new ArrayList<CustomLoginScreenPlugin>();
+    List<CustomLoginScreenPlugin> result = new ArrayList<>();
     
     for (PluginDescriptor plugin : getPlugins()) {
       if (plugin instanceof CustomLoginScreenPlugin) {
@@ -267,6 +267,6 @@ public class PluginManager {
 //  private List<Exclusion> applicationProvidedArtifacts = new ArrayList<>();
   private LibraryLoader libraryLoader;
   private MavenClient mavenClient;
-  private List<PluginDescriptor> plugins = new ArrayList<PluginDescriptor>();
+  private List<PluginDescriptor> plugins = new ArrayList<>();
 }
  

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
@@ -58,11 +58,11 @@ public class AuthenticationProviderVault {
   }
   
   public boolean hasExternalStrategies() {
-    return getExternalAuthenticationProviders().size() > 0;
+    return !getExternalAuthenticationProviders().isEmpty();
   }
   
   public boolean hasInternalStrategies() {
-    return getInternalAuthenticationProviders().size() > 0;
+    return !getInternalAuthenticationProviders().isEmpty();
   }
   
   /**

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
@@ -81,7 +81,7 @@ public class AuthenticationProviderVault {
   **/
   public void initializeStrategies() {
     String strategiesConf = System.getProperty("authentication.enabledStrategies");
-    if ((strategiesConf == null)||("".equals(strategiesConf)))
+    if (strategiesConf == null || "".equals(strategiesConf))
       strategiesConf = "internal";
     
     int authSourceCount = 0;

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
@@ -35,7 +35,7 @@ public class AuthenticationProviderVault {
   }
   
   public List<InternalAuthenticationProvider> getInternalAuthenticationProviders() {
-    List<InternalAuthenticationProvider> internalAuthenticationProviders = new ArrayList<InternalAuthenticationProvider>();
+    List<InternalAuthenticationProvider> internalAuthenticationProviders = new ArrayList<>();
     for (AuthenticationProvider authenticationProvider : getAuthenticationProviders()) {
       if (authenticationProvider instanceof InternalAuthenticationProvider)
         internalAuthenticationProviders.add((InternalAuthenticationProvider) authenticationProvider);
@@ -44,7 +44,7 @@ public class AuthenticationProviderVault {
   }
   
   public List<ExternalAuthenticationProvider> getExternalAuthenticationProviders() {
-    List<ExternalAuthenticationProvider> externalAuthenticationProviders = new ArrayList<ExternalAuthenticationProvider>();
+    List<ExternalAuthenticationProvider> externalAuthenticationProviders = new ArrayList<>();
     for (AuthenticationProvider authenticationProvider : getAuthenticationProviders()) {
       if (authenticationProvider instanceof ExternalAuthenticationProvider)
         externalAuthenticationProviders.add((ExternalAuthenticationProvider) authenticationProvider);
@@ -118,7 +118,7 @@ public class AuthenticationProviderVault {
   }
   
   /** Map containing authentication provider names as keys and the providers themselves as values */ 
-  private Map<String, AuthenticationProvider> authenticationProviders = new HashMap<String, AuthenticationProvider>();
+  private Map<String, AuthenticationProvider> authenticationProviders = new HashMap<>();
   
   @SuppressWarnings("unchecked")
   public static void registerAuthenticationProviderClass(String name, Class<?> class1) {
@@ -128,7 +128,7 @@ public class AuthenticationProviderVault {
   /** The singleton instance of this class */
   private static AuthenticationProviderVault instance = new AuthenticationProviderVault();
   /** All registered authentication provider classes **/
-  private static Map<String, Class<AuthenticationProvider>> authenticationProviderClasses = new HashMap<String, Class<AuthenticationProvider>>();
+  private static Map<String, Class<AuthenticationProvider>> authenticationProviderClasses = new HashMap<>();
   
   static {
     List<PluginDescriptor> plugins = PluginManager.getInstance().getPlugins();

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/maven/LocalWorkspaceReader.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/maven/LocalWorkspaceReader.java
@@ -50,7 +50,7 @@ public class LocalWorkspaceReader implements WorkspaceReader {
       return Arrays.asList(hostedArtifactMeta.getVersion());
     }
     
-    return new ArrayList<String>();
+    return new ArrayList<>();
   }
   
   @Override
@@ -137,7 +137,7 @@ public class LocalWorkspaceReader implements WorkspaceReader {
   
   private WorkspaceRepository workspaceRepository = new WorkspaceRepository();
   private File workspaceDirectory;
-  private List<HostedArtifactMeta> hostedArtifacts = new ArrayList<HostedArtifactMeta>();
+  private List<HostedArtifactMeta> hostedArtifacts = new ArrayList<>();
   
   private class HostedArtifactMeta {
     

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/maven/LocalWorkspaceReader.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/maven/LocalWorkspaceReader.java
@@ -97,7 +97,7 @@ public class LocalWorkspaceReader implements WorkspaceReader {
             }
           }
 
-          if ((artifactId != null) && (groupId != null) && (version != null)) {
+          if (artifactId != null && groupId != null && version != null) {
             hostedArtifacts.add(new HostedArtifactMeta(projectFolder, artifactId, groupId, version));
           }
 

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/maven/MavenClient.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/maven/MavenClient.java
@@ -355,7 +355,7 @@ public class MavenClient {
   private DefaultRepositorySystem repositorySystem;
   private DefaultLocalRepositoryProvider localRepositoryProvider;
   private LocalRepositoryManagerFactory localRepositoryManagerFactory = new SimpleLocalRepositoryManagerFactory();
-  private List<RemoteRepository> remoteRepositories = new ArrayList<RemoteRepository>();
+  private List<RemoteRepository> remoteRepositories = new ArrayList<>();
   private String localRepositoryPath;
   private ArtifactResolver artifactResolver;
   private ArtifactDescriptorReader artifactDescriptorReader;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/I18N/JavaScriptMessages.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/I18N/JavaScriptMessages.java
@@ -77,8 +77,8 @@ public class JavaScriptMessages {
     // TODO: how about plugins
   }
   
-  private List<String> bundleNames = new ArrayList<String>();
-  private Map<Locale, ResourceBundle> bundles = new HashMap<Locale, ResourceBundle>();
+  private List<String> bundleNames = new ArrayList<>();
+  private Map<Locale, ResourceBundle> bundles = new HashMap<>();
   
   static {
     instance = new JavaScriptMessages();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/I18N/Messages.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/I18N/Messages.java
@@ -81,8 +81,8 @@ public class Messages {
     bundleNames.add("fi.otavanopisto.pyramus.I18N.pyramuslocale");
   }
   
-  private List<String> bundleNames = new ArrayList<String>();
-  private Map<Locale, ResourceBundle> bundles = new HashMap<Locale, ResourceBundle>();
+  private List<String> bundleNames = new ArrayList<>();
+  private Map<Locale, ResourceBundle> bundles = new HashMap<>();
   
   static {
     instance = new Messages();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/I18N/ResourceBundleDelegate.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/I18N/ResourceBundleDelegate.java
@@ -39,7 +39,7 @@ public class ResourceBundleDelegate extends ResourceBundle {
     mergedKeys.addAll(resourceBundle.keySet());
   } 
 
-  private Set<ResourceBundle> bundles = new LinkedHashSet<ResourceBundle>();
-  private Vector<String> mergedKeys = new Vector<String>();
+  private Set<ResourceBundle> bundles = new LinkedHashSet<>();
+  private Vector<String> mergedKeys = new Vector<>();
   private Locale locale;
 }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/binary/reports/DownloadReportBinaryRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/binary/reports/DownloadReportBinaryRequestController.java
@@ -137,7 +137,7 @@ public class DownloadReportBinaryRequestController extends BinaryRequestControll
   }
   
 
-  private static Set<String> reservedParameters = new HashSet<String>();
+  private static Set<String> reservedParameters = new HashSet<>();
   
   static {
     reservedParameters.add("reportId");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/binary/settings/TransferCreditCourseNameAutoCompleteBinaryRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/binary/settings/TransferCreditCourseNameAutoCompleteBinaryRequestController.java
@@ -107,7 +107,7 @@ public class TransferCreditCourseNameAutoCompleteBinaryRequestController extends
     
     String localizedSubject = subjectName;
     
-    if ((subjectCode != null) && (subjectEducationType != null)) {
+    if (subjectCode != null && subjectEducationType != null) {
       localizedSubject = Messages.getInstance().getText(locale, 
           "generic.subjectFormatterWithEducationType", new Object[] {
         subjectCode,

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/breadcrumbs/BreadcrumbHandler.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/breadcrumbs/BreadcrumbHandler.java
@@ -119,6 +119,6 @@ public class BreadcrumbHandler {
     return sb.toString();
   }
   
-  private List<Breadcrumb> breadcrumbs = new ArrayList<Breadcrumb>();
+  private List<Breadcrumb> breadcrumbs = new ArrayList<>();
 
 }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/changelog/ChangeLogJPAEventsListener.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/changelog/ChangeLogJPAEventsListener.java
@@ -153,7 +153,7 @@ public class ChangeLogJPAEventsListener implements MessageListener {
 
     Class<?> entityClass = Class.forName(entityClassName);
     Object entity = systemDAO.findEntityById(entityClass, id);
-    Map<ChangeLogEntryEntityProperty, String> values = new HashMap<ChangeLogEntryEntityProperty, String>();
+    Map<ChangeLogEntryEntityProperty, String> values = new HashMap<>();
     
     // First we need to check if ChangeLogEntryEntity is already in the database
     ChangeLogEntryEntity changeLogEntryEntity = entryEntityDAO.findByName(entityClassName);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/CreateCourseJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/CreateCourseJSONRequestController.java
@@ -271,7 +271,7 @@ public class CreateCourseJSONRequestController extends JSONRequestController {
     User loggedUser = userDAO.findById(requestContext.getLoggedUserId());
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -359,7 +359,7 @@ public class CreateCourseJSONRequestController extends JSONRequestController {
 
     // Education types and subtypes submitted from the web page
 
-    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<Long, Vector<Long>>();
+    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<>();
     Enumeration<String> parameterNames = requestContext.getRequest().getParameterNames();
     while (parameterNames.hasMoreElements()) {
       name = (String) parameterNames.nextElement();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/CreateCourseJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/CreateCourseJSONRequestController.java
@@ -301,7 +301,7 @@ public class CreateCourseJSONRequestController extends JSONRequestController {
       Long descriptionCatId = requestContext.getLong(varName + ".catId");
       String descriptionText = requestContext.getString(varName + ".text");
 
-      if ((descriptionCatId != null) && (descriptionCatId.intValue() != -1)) {
+      if (descriptionCatId != null && descriptionCatId.intValue() != -1) {
         // Description has been submitted from form 
         descriptionDAO.create(course, cat, descriptionText);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/EditCourseJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/EditCourseJSONRequestController.java
@@ -376,7 +376,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
 
       CourseDescription oldDesc = descriptionDAO.findByCourseAndCategory(course, cat);
 
-      if ((descriptionCatId != null) && (descriptionCatId.intValue() != -1)) {
+      if (descriptionCatId != null && descriptionCatId.intValue() != -1) {
         // Description has been submitted from form 
         if (oldDesc != null)
           descriptionDAO.update(oldDesc, course, cat, descriptionText);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/EditCourseJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/EditCourseJSONRequestController.java
@@ -284,7 +284,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
     if (!course.getVersion().equals(version))
       throw new StaleObjectStateException(Course.class.getName(), course.getId());
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -309,7 +309,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
     
     // Education types and subtypes submitted from the web page
 
-    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<Long, Vector<Long>>();
+    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<>();
     Enumeration<String> parameterNames = requestContext.getRequest().getParameterNames();
     while (parameterNames.hasMoreElements()) {
       name = (String) parameterNames.nextElement();
@@ -367,7 +367,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
     // Course Descriptions
     
     List<CourseDescriptionCategory> descriptionCategories = descriptionCategoryDAO.listUnarchived();
-    Set<CourseDescription> nonExistingDescriptions = new HashSet<CourseDescription>();
+    Set<CourseDescription> nonExistingDescriptions = new HashSet<>();
     
     for (CourseDescriptionCategory cat: descriptionCategories) {
       String varName = "courseDescription." + cat.getId().toString();
@@ -396,7 +396,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
     
     // Personnel
 
-    Set<Long> existingIds = new HashSet<Long>();
+    Set<Long> existingIds = new HashSet<>();
     int rowCount = requestContext.getInteger("personnelTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "personnelTable." + i;
@@ -474,7 +474,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
     
     // Basic course resources
 
-    existingIds = new HashSet<Long>();
+    existingIds = new HashSet<>();
     rowCount = requestContext.getInteger("basicResourcesTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "basicResourcesTable." + i;
@@ -509,7 +509,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
 
     // Student course resources
 
-    existingIds = new HashSet<Long>();
+    existingIds = new HashSet<>();
     rowCount = requestContext.getInteger("studentResourcesTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "studentResourcesTable." + i;
@@ -543,7 +543,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
 
     // Grade course resources
 
-    existingIds = new HashSet<Long>();
+    existingIds = new HashSet<>();
     rowCount = requestContext.getInteger("gradeResourcesTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "gradeResourcesTable." + i;
@@ -576,7 +576,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
 
     // Other costs
 
-    existingIds = new HashSet<Long>();
+    existingIds = new HashSet<>();
     rowCount = requestContext.getInteger("otherCostsTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "otherCostsTable." + i;
@@ -601,7 +601,7 @@ public class EditCourseJSONRequestController extends JSONRequestController {
 
     // Students
 
-    existingIds = new HashSet<Long>();
+    existingIds = new HashSet<>();
     rowCount = requestContext.getInteger("studentsTable.rowCount");
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "studentsTable." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/SaveCourseAssessmentsJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/SaveCourseAssessmentsJSONRequestController.java
@@ -64,7 +64,7 @@ public class SaveCourseAssessmentsJSONRequestController extends JSONRequestContr
       String colPrefix = "studentsTable." + i;
 
       Long modified = requestContext.getLong(colPrefix + ".modified");
-      if ((modified == null) || (modified.intValue() != 1))
+      if (modified == null || modified.intValue() != 1)
         continue;
       
       Long courseStudentId = requestContext.getLong(colPrefix + ".courseStudentId");
@@ -84,7 +84,7 @@ public class SaveCourseAssessmentsJSONRequestController extends JSONRequestContr
         CourseAssessment assessment = courseAssessmentDAO.findByCourseStudent(courseStudent);
 
         Long verbalModified = requestContext.getLong(colPrefix + ".verbalModified");
-        if ((verbalModified != null) && (verbalModified.intValue() == 1)) {
+        if (verbalModified != null && verbalModified.intValue() == 1) {
           verbalAssessment = requestContext.getString(colPrefix + ".verbalAssessment");
         } else {
           if (assessment != null)

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/SearchCoursesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/SearchCoursesJSONRequestController.java
@@ -149,11 +149,11 @@ public class SearchCoursesJSONRequestController extends JSONRequestController {
       searchResult = courseDAO.searchCoursesBasic(resultsPerPage, page, text, true);
     }
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
 
     List<Course> courses = searchResult.getResults();
     for (Course course : courses) {
-      Map<String, Object> courseInfo = new HashMap<String, Object>();
+      Map<String, Object> courseInfo = new HashMap<>();
       courseInfo.put("id", course.getId());
       courseInfo.put("name", course.getName());
       courseInfo.put("nameExtension", course.getNameExtension());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/grading/LoadTransferCreditTemplateJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/grading/LoadTransferCreditTemplateJSONRequestController.java
@@ -36,10 +36,10 @@ public class LoadTransferCreditTemplateJSONRequestController extends JSONRequest
     Long transferCreditTemplateId = jsonRequestContext.getLong("transferCreditTemplateId");
     TransferCreditTemplate transferCreditTemplate = transferCreditTemplateDAO.findById(transferCreditTemplateId);
     
-    List<Map<String, Object>> results = new ArrayList<Map<String,Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     
     for (TransferCreditTemplateCourse templateCourse : transferCreditTemplate.getCourses()) {
-      Map<String, Object> result = new HashMap<String, Object>();
+      Map<String, Object> result = new HashMap<>();
       
       String subjectName = templateCourse.getSubject().getName();
       String subjectCode = templateCourse.getSubject().getCode();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/grading/LoadTransferCreditTemplateJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/grading/LoadTransferCreditTemplateJSONRequestController.java
@@ -47,7 +47,7 @@ public class LoadTransferCreditTemplateJSONRequestController extends JSONRequest
       
       String localizedSubject = subjectName;
       
-      if ((subjectCode != null) && (subjectEducationType != null)) {
+      if (subjectCode != null && subjectEducationType != null) {
         localizedSubject = Messages.getInstance().getText(jsonRequestContext.getRequest().getLocale(), 
             "generic.subjectFormatterWithEducationType", new Object[] {
           subjectCode,

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/help/SearchHelpJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/help/SearchHelpJSONRequestController.java
@@ -30,7 +30,7 @@ public class SearchHelpJSONRequestController extends JSONRequestController {
     
     searchResult = helpPageDAO.searchHelpPagesBasic(MAX_HELP_PAGES, 0, text);
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
 
     List<HelpPage> helpPages = searchResult.getResults();
     for (HelpPage helpPage : helpPages) {
@@ -46,7 +46,7 @@ public class SearchHelpJSONRequestController extends JSONRequestController {
         }
         
         if (!found) {
-          Map<String, Object> folderInfo = new HashMap<String, Object>();
+          Map<String, Object> folderInfo = new HashMap<>();
           
           folderInfo.put("id", parent.getId());
           folderInfo.put("type", "folder");
@@ -68,7 +68,7 @@ public class SearchHelpJSONRequestController extends JSONRequestController {
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> pages = (List<Map<String, Object>>) folderInfo.get("pages");
             
-            Map<String, Object> helpPageInfo = new HashMap<String, Object>();
+            Map<String, Object> helpPageInfo = new HashMap<>();
             helpPageInfo.put("id", helpPage.getId());
             helpPageInfo.put("type", "page");
             helpPageInfo.put("title", helpPage.getTitleByLocale(requestContext.getRequest().getLocale()).getTitle());
@@ -78,7 +78,7 @@ public class SearchHelpJSONRequestController extends JSONRequestController {
           }
         }
       } else {
-        Map<String, Object> helpPageInfo = new HashMap<String, Object>();
+        Map<String, Object> helpPageInfo = new HashMap<>();
         helpPageInfo.put("id", helpPage.getId());
         helpPageInfo.put("type", "page");
         helpPageInfo.put("title", helpPage.getTitleByLocale(requestContext.getRequest().getLocale()).getTitle());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/locale/GetJavaScriptLocaleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/locale/GetJavaScriptLocaleJSONRequestController.java
@@ -15,7 +15,7 @@ import fi.otavanopisto.pyramus.framework.UserRole;
 public class GetJavaScriptLocaleJSONRequestController extends JSONRequestController {
   
   public void process(JSONRequestContext requestContext) {
-    Map<String, String> localeStrings = new HashMap<String, String>();
+    Map<String, String> localeStrings = new HashMap<>();
     
     ResourceBundle resourceBundle = JavaScriptMessages.getInstance().getResourceBundle(requestContext.getRequest().getLocale());
     Enumeration<String> keys = resourceBundle.getKeys();
@@ -25,7 +25,7 @@ public class GetJavaScriptLocaleJSONRequestController extends JSONRequestControl
       localeStrings.put(key, value.trim());
     }
 
-    Map<String, String> settingStrings = new HashMap<String, String>();
+    Map<String, String> settingStrings = new HashMap<>();
     DateFormat shortDate = SimpleDateFormat.getDateInstance(DateFormat.SHORT, requestContext.getRequest().getLocale());
     DateFormat longDate = SimpleDateFormat.getDateInstance(DateFormat.LONG, requestContext.getRequest().getLocale());
     DateFormat time = SimpleDateFormat.getTimeInstance(DateFormat.SHORT, requestContext.getRequest().getLocale());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/CreateModuleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/CreateModuleJSONRequestController.java
@@ -76,7 +76,7 @@ public class CreateModuleJSONRequestController extends JSONRequestController {
     Double moduleLength = requestContext.getDouble("moduleLength");
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -125,7 +125,7 @@ public class CreateModuleJSONRequestController extends JSONRequestController {
 
     // Education types and subtypes submitted from the web page
 
-    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<Long, Vector<Long>>();
+    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<>();
     Enumeration<String> parameterNames = requestContext.getRequest().getParameterNames();
     while (parameterNames.hasMoreElements()) {
       name = (String) parameterNames.nextElement();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/CreateModuleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/CreateModuleJSONRequestController.java
@@ -104,7 +104,7 @@ public class CreateModuleJSONRequestController extends JSONRequestController {
       Long descriptionCatId = requestContext.getLong(varName + ".catId");
       String descriptionText = requestContext.getString(varName + ".text");
 
-      if ((descriptionCatId != null) && (descriptionCatId.intValue() != -1)) {
+      if (descriptionCatId != null && descriptionCatId.intValue() != -1) {
         descriptionDAO.create(module, cat, descriptionText);
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/EditModuleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/EditModuleJSONRequestController.java
@@ -73,7 +73,7 @@ public class EditModuleJSONRequestController extends JSONRequestController {
     
     // Education types and subtypes submitted from the web page
 
-    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<Long, Vector<Long>>();
+    Map<Long, Vector<Long>> chosenEducationTypes = new HashMap<>();
     Enumeration<String> parameterNames = requestContext.getRequest().getParameterNames();
     while (parameterNames.hasMoreElements()) {
       String name = (String) parameterNames.nextElement();
@@ -93,7 +93,7 @@ public class EditModuleJSONRequestController extends JSONRequestController {
     // Course Descriptions
     
     List<CourseDescriptionCategory> descriptionCategories = descriptionCategoryDAO.listUnarchived();
-    Set<CourseDescription> nonExistingDescriptions = new HashSet<CourseDescription>();
+    Set<CourseDescription> nonExistingDescriptions = new HashSet<>();
     
     for (CourseDescriptionCategory cat: descriptionCategories) {
       String varName = "courseDescription." + cat.getId().toString();
@@ -195,7 +195,7 @@ public class EditModuleJSONRequestController extends JSONRequestController {
     Long maxParticipantCount = requestContext.getLong("maxParticipantCount");
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/EditModuleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/EditModuleJSONRequestController.java
@@ -102,7 +102,7 @@ public class EditModuleJSONRequestController extends JSONRequestController {
 
       CourseDescription oldDesc = courseDescriptionDAO.findByCourseAndCategory(module, cat);
 
-      if ((descriptionCatId != null) && (descriptionCatId.intValue() != -1)) {
+      if (descriptionCatId != null && descriptionCatId.intValue() != -1) {
         // Description has been submitted from form 
         if (oldDesc != null)
           courseDescriptionDAO.update(oldDesc, module, cat, descriptionText);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/SearchModulesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/SearchModulesJSONRequestController.java
@@ -84,10 +84,10 @@ public class SearchModulesJSONRequestController extends JSONRequestController {
       searchResult = moduleDAO.searchModulesBasic(resultsPerPage, page, text);
     }
     
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<Module> modules = searchResult.getResults();
     for (Module module : modules) {
-      Map<String, Object> moduleInfo = new HashMap<String, Object>();
+      Map<String, Object> moduleInfo = new HashMap<>();
       moduleInfo.put("id", module.getId());
       moduleInfo.put("name", module.getName());
       results.add(moduleInfo);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/CreateProjectJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/CreateProjectJSONRequestController.java
@@ -41,7 +41,7 @@ public class CreateProjectJSONRequestController extends JSONRequestController {
     String description = jsonRequestContext.getRequest().getParameter("description");
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/CreateStudentProjectJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/CreateStudentProjectJSONRequestController.java
@@ -46,7 +46,7 @@ public class CreateStudentProjectJSONRequestController extends JSONRequestContro
     Long projectId = NumberUtils.createLong(jsonRequestContext.getRequest().getParameter("projectId"));
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/EditProjectJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/EditProjectJSONRequestController.java
@@ -57,7 +57,7 @@ public class EditProjectJSONRequestController extends JSONRequestController {
     Double optionalStudiesLength = jsonRequestContext.getDouble("optionalStudiesLength");
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -85,7 +85,7 @@ public class EditProjectJSONRequestController extends JSONRequestController {
 
     // Project modules
 
-    Set<Long> existingIds = new HashSet<Long>();
+    Set<Long> existingIds = new HashSet<>();
     int rowCount = jsonRequestContext.getInteger("modulesTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "modulesTable." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/EditStudentProjectJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/EditStudentProjectJSONRequestController.java
@@ -84,7 +84,7 @@ public class EditStudentProjectJSONRequestController extends JSONRequestControll
     Long studentId = jsonRequestContext.getLong("student");
     CourseOptionality projectOptionality = (CourseOptionality) jsonRequestContext.getEnum("projectOptionality", CourseOptionality.class);
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -151,7 +151,7 @@ public class EditStudentProjectJSONRequestController extends JSONRequestControll
     
     // Student project modules
 
-    Set<Long> existingModuleIds = new HashSet<Long>();
+    Set<Long> existingModuleIds = new HashSet<>();
     rowCount = jsonRequestContext.getInteger("modulesTable.rowCount").intValue();
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "modulesTable." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/GetProjectModulesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/GetProjectModulesJSONRequestController.java
@@ -26,9 +26,9 @@ public class GetProjectModulesJSONRequestController extends JSONRequestControlle
     Long projectId = NumberUtils.createLong(jsonRequestContext.getRequest().getParameter("project"));
     Project project = projectDAO.findById(projectId);
 
-    List<Map<String, Object>> projectModules = new ArrayList<Map<String,Object>>();
+    List<Map<String, Object>> projectModules = new ArrayList<>();
     for (ProjectModule projectModule : project.getProjectModules()) {
-      Map<String, Object> moduleInfo = new HashMap<String, Object>();
+      Map<String, Object> moduleInfo = new HashMap<>();
       moduleInfo.put("id", projectModule.getId());
       moduleInfo.put("moduleId", projectModule.getModule().getId());
       moduleInfo.put("name", projectModule.getModule().getName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchModulesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchModulesJSONRequestController.java
@@ -47,10 +47,10 @@ public class SearchModulesJSONRequestController extends JSONRequestController {
 
     SearchResult<Module> searchResult = moduleDAO.searchModules(resultsPerPage, page, projectName, name, tags, null, null, null, null, true);
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<Module> modules = searchResult.getResults();
     for (Module module : modules) {
-      Map<String, Object> moduleInfo = new HashMap<String, Object>();
+      Map<String, Object> moduleInfo = new HashMap<>();
       moduleInfo.put("id", module.getId());
       moduleInfo.put("name", module.getName());
       results.add(moduleInfo);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchProjectsJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchProjectsJSONRequestController.java
@@ -45,10 +45,10 @@ public class SearchProjectsJSONRequestController extends JSONRequestController {
 
     SearchResult<Project> searchResult = projectDAO.searchProjectsBasic(resultsPerPage, page, text);
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<Project> projects = searchResult.getResults();
     for (Project project : projects) {
-      Map<String, Object> projectInfo = new HashMap<String, Object>();
+      Map<String, Object> projectInfo = new HashMap<>();
       projectInfo.put("id", project.getId());
       projectInfo.put("name", project.getName());
       results.add(projectInfo);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchStudentProjectCoursesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchStudentProjectCoursesJSONRequestController.java
@@ -39,13 +39,13 @@ public class SearchStudentProjectCoursesJSONRequestController extends JSONReques
     
     SearchResult<Course> searchResult = courseDAO.searchCourses(resultsPerPage, page, name, tags, null, null, null, null, null, null, null, true);
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<Course> courses = searchResult.getResults();
     for (Course course : courses) {
       Long studentCount = courseStudentDAO.countByCourse(course);
       Long maxStudentCount = course.getMaxParticipantCount();
       
-      Map<String, Object> courseInfo = new HashMap<String, Object>();
+      Map<String, Object> courseInfo = new HashMap<>();
       courseInfo.put("id", course.getId());
       courseInfo.put("name", course.getName());
       courseInfo.put("nameExtension", course.getNameExtension());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchStudentProjectsJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/projects/SearchStudentProjectsJSONRequestController.java
@@ -46,10 +46,10 @@ public class SearchStudentProjectsJSONRequestController extends JSONRequestContr
 
     SearchResult<StudentProject> searchResult = studentProjectDAO.searchStudentProjectsBasic(resultsPerPage, page, projectText, studentText);
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<StudentProject> studentProjects = searchResult.getResults();
     for (StudentProject studentProject : studentProjects) {
-      Map<String, Object> studentProjectInfo = new HashMap<String, Object>();
+      Map<String, Object> studentProjectInfo = new HashMap<>();
       studentProjectInfo.put("id", studentProject.getId());
       studentProjectInfo.put("studentProjectName", studentProject.getName());
       studentProjectInfo.put("studentFirstName", studentProject.getStudent().getFirstName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/reports/EditReportJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/reports/EditReportJSONRequestController.java
@@ -44,9 +44,9 @@ public class EditReportJSONRequestController extends JSONRequestController {
       
       boolean selected = requestContext.getBoolean("context." + contextType.toString());
       
-      if ((selected) && (context == null))
+      if (selected && context == null)
         reportContextDAO.create(report, contextType);
-      else if ((!selected) && (context != null))
+      else if (!selected && context != null)
         reportContextDAO.delete(context);
     }
 

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/CreateMaterialResourceJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/CreateMaterialResourceJSONRequestController.java
@@ -33,7 +33,7 @@ public class CreateMaterialResourceJSONRequestController extends JSONRequestCont
     ResourceCategory resourceCategory = resourceCategoryDAO.findById(NumberUtils.createLong(jsonRequestContext.getRequest().getParameter("category")));
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/CreateWorkResourceJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/CreateWorkResourceJSONRequestController.java
@@ -34,7 +34,7 @@ public class CreateWorkResourceJSONRequestController extends JSONRequestControll
     ResourceCategory resourceCategory = resourceCategoryDAO.findById(NumberUtils.createLong(jsonRequestContext.getRequest().getParameter("category")));
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/EditMaterialResourceJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/EditMaterialResourceJSONRequestController.java
@@ -37,7 +37,7 @@ public class EditMaterialResourceJSONRequestController extends JSONRequestContro
     Long version = NumberUtils.createLong(jsonRequestContext.getRequest().getParameter("version"));
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/EditWorkResourceJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/EditWorkResourceJSONRequestController.java
@@ -38,7 +38,7 @@ public class EditWorkResourceJSONRequestController extends JSONRequestController
     Long version = NumberUtils.createLong(jsonRequestContext.getRequest().getParameter("version"));
     String tagsText = jsonRequestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/SearchResourcesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/resources/SearchResourcesJSONRequestController.java
@@ -64,7 +64,7 @@ public class SearchResourcesJSONRequestController extends JSONRequestController 
     }
     
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
 
     List<Resource> resources = searchResult.getResults();
     for (Resource resource : resources) {
@@ -81,7 +81,7 @@ public class SearchResourcesJSONRequestController extends JSONRequestController 
         hourlyCost = ((WorkResource) resource).getHourlyCost().getAmount();
       }
       
-      Map<String, Object> resourceInfo = new HashMap<String, Object>();
+      Map<String, Object> resourceInfo = new HashMap<>();
       resourceInfo.put("id", resource.getId());
       resourceInfo.put("name", resource.getName());
       resourceInfo.put("resourceType", resource.getResourceType());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/CreateSchoolJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/CreateSchoolJSONRequestController.java
@@ -52,7 +52,7 @@ public class CreateSchoolJSONRequestController extends JSONRequestController {
     
     Long schoolFieldId = requestContext.getLong("schoolFieldId");
     SchoolField schoolField = null;
-    if ((schoolFieldId != null) && (schoolFieldId.intValue() >= 0))
+    if (schoolFieldId != null && schoolFieldId.intValue() >= 0)
       schoolField = schoolFieldDAO.findById(schoolFieldId);
 
     Set<Tag> tagEntities = new HashSet<>();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/CreateSchoolJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/CreateSchoolJSONRequestController.java
@@ -55,7 +55,7 @@ public class CreateSchoolJSONRequestController extends JSONRequestController {
     if ((schoolFieldId != null) && (schoolFieldId.intValue() >= 0))
       schoolField = schoolFieldDAO.findById(schoolFieldId);
 
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/EditGradingScaleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/EditGradingScaleJSONRequestController.java
@@ -29,7 +29,7 @@ public class EditGradingScaleJSONRequestController extends JSONRequestController
     GradingScale gradingScale = gradingScaleDAO.findById(gradingScaleId);
     gradingScaleDAO.update(gradingScale, name, description);
     
-    Set<Long> existingGrades = new HashSet<Long>();
+    Set<Long> existingGrades = new HashSet<>();
     
     int rowCount = NumberUtils.createInteger(jsonRequestContext.getRequest().getParameter("gradesTable.rowCount")).intValue();
     for (int i = 0; i < rowCount; i++) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/EditSchoolJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/EditSchoolJSONRequestController.java
@@ -62,7 +62,7 @@ public class EditSchoolJSONRequestController extends JSONRequestController {
     String schoolName = requestContext.getString("name");
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -83,7 +83,7 @@ public class EditSchoolJSONRequestController extends JSONRequestController {
 
     // Addresses
     
-    Set<Long> existingAddresses = new HashSet<Long>();
+    Set<Long> existingAddresses = new HashSet<>();
     int addressCount = requestContext.getInteger("addressTable.rowCount");
     for (int i = 0; i < addressCount; i++) {
       String colPrefix = "addressTable." + i;
@@ -118,7 +118,7 @@ public class EditSchoolJSONRequestController extends JSONRequestController {
 
     // E-mail addresses
     
-    Set<Long> existingEmails = new HashSet<Long>();
+    Set<Long> existingEmails = new HashSet<>();
     int emailCount = requestContext.getInteger("emailTable.rowCount");
     for (int i = 0; i < emailCount; i++) {
       String colPrefix = "emailTable." + i;
@@ -149,7 +149,7 @@ public class EditSchoolJSONRequestController extends JSONRequestController {
 
     // Phone numbers
     
-    Set<Long> existingPhoneNumbers = new HashSet<Long>();
+    Set<Long> existingPhoneNumbers = new HashSet<>();
     int phoneCount = requestContext.getInteger("phoneTable.rowCount");
     for (int i = 0; i < phoneCount; i++) {
       String colPrefix = "phoneTable." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/SearchSchoolsJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/settings/SearchSchoolsJSONRequestController.java
@@ -45,10 +45,10 @@ public class SearchSchoolsJSONRequestController extends JSONRequestController {
 
     SearchResult<School> searchResult = schoolDAO.searchSchoolsBasic(resultsPerPage, page, text);
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<School> schools = searchResult.getResults();
     for (School school : schools) {
-      Map<String, Object> schoolInfo = new HashMap<String, Object>();
+      Map<String, Object> schoolInfo = new HashMap<>();
       schoolInfo.put("id", school.getId());
       schoolInfo.put("name", school.getName());
       schoolInfo.put("fieldName", school.getField() != null ? school.getField().getName() : "");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CopyStudentStudyProgrammeJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CopyStudentStudyProgrammeJSONRequestController.java
@@ -92,7 +92,7 @@ public class CopyStudentStudyProgrammeJSONRequestController extends JSONRequestC
     
     // Default user
     
-    if ((person.getDefaultUser() == null) || (Boolean.TRUE.equals(setAsDefaultUser))) {
+    if (person.getDefaultUser() == null || Boolean.TRUE.equals(setAsDefaultUser)) {
       personDAO.updateDefaultUser(person, newStudent);
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateContactEntryCommentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateContactEntryCommentJSONRequestController.java
@@ -56,7 +56,7 @@ public class CreateContactEntryCommentJSONRequestController extends JSONRequestC
       
       StudentContactLogEntryComment comment = entryCommentDAO.create(entry, commentText, commentDate, commentCreatorName);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", comment.getId());
       info.put("creatorName", comment.getCreatorName());
       info.put("timestamp", comment.getCommentDate().getTime());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateContactEntryJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateContactEntryJSONRequestController.java
@@ -60,7 +60,7 @@ public class CreateContactEntryJSONRequestController extends JSONRequestControll
       
       StudentContactLogEntry entry = contactLogEntryDAO.create(student, entryType, entryText, entryDate, entryCreator);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", entry.getId());
       info.put("creatorName", entry.getCreatorName());
       info.put("timestamp", entry.getEntryDate().getTime());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateGroupContactEntryCommentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateGroupContactEntryCommentJSONRequestController.java
@@ -56,7 +56,7 @@ public class CreateGroupContactEntryCommentJSONRequestController extends JSONReq
       
       StudentGroupContactLogEntryComment comment = entryCommentDAO.create(entry, commentText, commentDate, commentCreatorName);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", comment.getId());
       info.put("creatorName", comment.getCreatorName());
       info.put("timestamp", comment.getCommentDate() != null ? comment.getCommentDate().getTime() : "");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateGroupContactEntryJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateGroupContactEntryJSONRequestController.java
@@ -59,7 +59,7 @@ public class CreateGroupContactEntryJSONRequestController extends JSONRequestCon
       
       StudentGroupContactLogEntry entry = contactLogEntryDAO.create(studentGroup, entryType, entryText, entryDate, entryCreator);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", entry.getId());
       info.put("creatorName", entry.getCreatorName());
       info.put("timestamp", entry.getEntryDate() != null ? entry.getEntryDate().getTime() : "");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentGroupJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentGroupJSONRequestController.java
@@ -41,7 +41,7 @@ public class CreateStudentGroupJSONRequestController extends JSONRequestControll
     Date beginDate = requestContext.getDate("beginDate");
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentJSONRequestController.java
@@ -102,7 +102,7 @@ public class CreateStudentJSONRequestController extends JSONRequestController {
     String studyEndText = requestContext.getString("studyEndText");
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentProjectJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentProjectJSONRequestController.java
@@ -42,7 +42,7 @@ public class CreateStudentProjectJSONRequestController extends JSONRequestContro
     StudentProject studentProject = studentProjectDAO.create(student, project.getName(), project.getDescription(), 
         project.getOptionalStudiesLength().getUnits(), project.getOptionalStudiesLength().getUnit(), projectOptionality, loggedUser, project);
     
-    Set<Tag> tags = new HashSet<Tag>();
+    Set<Tag> tags = new HashSet<>();
     for (Tag tag : project.getTags()) {
       tags.add(tag);
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditContactEntryCommentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditContactEntryCommentJSONRequestController.java
@@ -54,7 +54,7 @@ public class EditContactEntryCommentJSONRequestController extends JSONRequestCon
       
       entryCommentDAO.update(comment, commentText, commentDate, commentCreatorName);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", comment.getId());
       info.put("creatorName", comment.getCreatorName());
       info.put("timestamp", comment.getCommentDate().getTime());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditContactEntryJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditContactEntryJSONRequestController.java
@@ -57,7 +57,7 @@ public class EditContactEntryJSONRequestController extends JSONRequestController
       
       logEntryDAO.update(entry, entryType, entryText, entryDate, entryCreator);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", entry.getId());
       info.put("creatorName", entry.getCreatorName());
       info.put("timestamp", entry.getEntryDate().getTime());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditGroupContactEntryCommentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditGroupContactEntryCommentJSONRequestController.java
@@ -53,7 +53,7 @@ public class EditGroupContactEntryCommentJSONRequestController extends JSONReque
       
       entryCommentDAO.update(comment, commentText, commentDate, commentCreatorName);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", comment.getId());
       info.put("creatorName", comment.getCreatorName());
       info.put("timestamp", comment.getCommentDate() != null ? comment.getCommentDate().getTime() : "");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditGroupContactEntryJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditGroupContactEntryJSONRequestController.java
@@ -58,7 +58,7 @@ public class EditGroupContactEntryJSONRequestController extends JSONRequestContr
       
       logEntryDAO.update(entry, entryType, entryText, entryDate, entryCreator);
 
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", entry.getId());
       info.put("creatorName", entry.getCreatorName());
       info.put("timestamp", entry.getEntryDate() != null ? entry.getEntryDate().getTime() : "");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentGroupJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentGroupJSONRequestController.java
@@ -57,7 +57,7 @@ public class EditStudentGroupJSONRequestController extends JSONRequestController
     Date beginDate = requestContext.getDate("beginDate");
     String tagsText = requestContext.getString("tags");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -89,7 +89,7 @@ public class EditStudentGroupJSONRequestController extends JSONRequestController
     StudentGroupUser[] users = studentGroup.getUsers().toArray(new StudentGroupUser[0]);
     StudentGroupStudent[] students = studentGroup.getStudents().toArray(new StudentGroupStudent[0]);
 
-    List<Long> removables = new ArrayList<Long>();
+    List<Long> removables = new ArrayList<>();
     Iterator<StudentGroupUser> userIterator = studentGroup.getUsers().iterator();
     while (userIterator.hasNext())
       removables.add(userIterator.next().getId());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
@@ -178,7 +178,7 @@ public class EditStudentJSONRequestController extends JSONRequestController {
 	    Boolean lodging = "1".equals(requestContext.getString("lodging." + student.getId()));
 	    String tagsText = requestContext.getString("tags." + student.getId());
 	    
-	    Set<Tag> tagEntities = new HashSet<Tag>();
+	    Set<Tag> tagEntities = new HashSet<>();
 	    if (!StringUtils.isBlank(tagsText)) {
 	      List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
 	      for (String tag : tags) {
@@ -244,7 +244,7 @@ public class EditStudentJSONRequestController extends JSONRequestController {
 	    
 	    // Student addresses
 	    
-	    Set<Long> existingAddresses = new HashSet<Long>();
+	    Set<Long> existingAddresses = new HashSet<>();
 	    int rowCount = requestContext.getInteger("addressTable." + student.getId() + ".rowCount");
 	    for (int i = 0; i < rowCount; i++) {
 	      String colPrefix = "addressTable." + student.getId() + "." + i;
@@ -279,7 +279,7 @@ public class EditStudentJSONRequestController extends JSONRequestController {
 
 	    // Email addresses
 
-	    Set<Long> existingEmails = new HashSet<Long>();
+	    Set<Long> existingEmails = new HashSet<>();
 	    rowCount = requestContext.getInteger("emailTable." + student.getId() + ".rowCount");
 	    for (int i = 0; i < rowCount; i++) {
 	      String colPrefix = "emailTable." + student.getId() + "." + i;
@@ -311,7 +311,7 @@ public class EditStudentJSONRequestController extends JSONRequestController {
 	    
 	    // Phone numbers
 	    
-      Set<Long> existingPhoneNumbers = new HashSet<Long>();
+      Set<Long> existingPhoneNumbers = new HashSet<>();
       rowCount = requestContext.getInteger("phoneTable." + student.getId() + ".rowCount");
       for (int i = 0; i < rowCount; i++) {
         String colPrefix = "phoneTable." + student.getId() + "." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetContactEntryCommentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetContactEntryCommentJSONRequestController.java
@@ -42,7 +42,7 @@ public class GetContactEntryCommentJSONRequestController extends JSONRequestCont
       
       StudentContactLogEntryComment comment = entryCommentDAO.findById(commentId);
       
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", comment.getId());
       info.put("entryId", comment.getEntry().getId());
       info.put("creatorName", comment.getCreatorName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetContactEntryJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetContactEntryJSONRequestController.java
@@ -44,7 +44,7 @@ public class GetContactEntryJSONRequestController extends JSONRequestController 
       
       StudentContactLogEntry entry = logEntryDAO.findById(entryId);
       
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", entry.getId());
       info.put("creatorName", entry.getCreatorName());
       info.put("timestamp", entry.getEntryDate().getTime());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetGroupContactEntryCommentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetGroupContactEntryCommentJSONRequestController.java
@@ -44,7 +44,7 @@ public class GetGroupContactEntryCommentJSONRequestController extends JSONReques
     try {
       StudentGroupContactLogEntryComment comment = entryCommentDAO.findById(commentId);
       
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", comment.getId());
       info.put("entryId", comment.getEntry().getId());
       info.put("creatorName", comment.getCreatorName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetGroupContactEntryJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetGroupContactEntryJSONRequestController.java
@@ -44,7 +44,7 @@ public class GetGroupContactEntryJSONRequestController extends JSONRequestContro
     try {
       StudentGroupContactLogEntry entry = logEntryDAO.findById(entryId);
       
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", entry.getId());
       info.put("creatorName", entry.getCreatorName());
       info.put("timestamp", entry.getEntryDate() != null ? entry.getEntryDate().getTime() : "");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetStudentInfoJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetStudentInfoJSONRequestController.java
@@ -39,7 +39,7 @@ public class GetStudentInfoJSONRequestController extends JSONRequestController {
     Long studentId = NumberUtils.createLong(requestContext.getRequest().getParameter("studentId"));
     Student student = studentDAO.findById(studentId);
     
-    Map<String, Object> studentInfo = new HashMap<String, Object>();
+    Map<String, Object> studentInfo = new HashMap<>();
     
     studentInfo.put("id", student.getId());
     studentInfo.put("firstname", student.getFirstName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetStudentStudyProgrammesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/GetStudentStudyProgrammesJSONRequestController.java
@@ -81,14 +81,14 @@ public class GetStudentStudyProgrammesJSONRequestController extends JSONRequestC
       }
     });
     
-    List<Map<String, Object>> result = new ArrayList<Map<String,Object>>();
+    List<Map<String, Object>> result = new ArrayList<>();
     
     for (int i = 0; i < students.size(); i++) {
     	Student student = students.get(i);
     	
       if (student != null) {
     		if (student.getStudyProgramme() != null) {
-          Map<String, Object> studentInfo = new HashMap<String, Object>();
+          Map<String, Object> studentInfo = new HashMap<>();
           studentInfo.put("studyProgrammeId", student.getStudyProgramme().getId());
 
           String studyProgrammeName = student.getStudyProgramme().getName();
@@ -101,7 +101,7 @@ public class GetStudentStudyProgrammesJSONRequestController extends JSONRequestC
 
           result.add(studentInfo);
     		} else {
-          Map<String, Object> studentInfo = new HashMap<String, Object>();
+          Map<String, Object> studentInfo = new HashMap<>();
           studentInfo.put("studyProgrammeId", new Long(-1));
           if (!student.getArchived())
             studentInfo.put("studyProgrammeName", Messages.getInstance().getText(requestContext.getRequest().getLocale(), "students.editStudent.noStudyProgrammeDropDownItemLabel"));

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentGroupsJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentGroupsJSONRequestController.java
@@ -86,11 +86,11 @@ public class SearchStudentGroupsJSONRequestController extends JSONRequestControl
       searchResult = studentGroupDAO.searchStudentGroupsBasic(resultsPerPage, page, text); 
     }
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
 
     List<StudentGroup> studentGroups = searchResult.getResults();
     for (StudentGroup studentGroup : studentGroups) {
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", studentGroup.getId());
       info.put("name", studentGroup.getName());
       if (studentGroup.getBeginDate() != null) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsDialogJSONRequestContoller.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsDialogJSONRequestContoller.java
@@ -62,12 +62,12 @@ public class SearchStudentsDialogJSONRequestContoller extends JSONRequestControl
 
     searchResult = personDAO.searchPersonsBasic(resultsPerPage, page, query, personFilter, studyProgramme, studentGroup);
     
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<Person> persons = searchResult.getResults();
     for (Person person : persons) {
     	Student student = person.getLatestStudent();
     	if (student != null) {
-        Map<String, Object> info = new HashMap<String, Object>();
+        Map<String, Object> info = new HashMap<>();
         info.put("personId", person.getId());
         info.put("id", student.getId());
         info.put("firstName", student.getFirstName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsJSONRequestContoller.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsJSONRequestContoller.java
@@ -119,7 +119,7 @@ public class SearchStudentsJSONRequestContoller extends JSONRequestController {
       searchResult = personDAO.searchPersonsBasic(resultsPerPage, page, query, PersonFilter.ALL);
     }
 
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<Person> persons = searchResult.getResults();
     for (Person person : persons) {
   	  List<Student> studentList2 = studentDAO.listByPerson(person);
@@ -162,7 +162,7 @@ public class SearchStudentsJSONRequestContoller extends JSONRequestController {
     	    }
     	  }
     	  
-        Map<String, Object> info = new HashMap<String, Object>();
+        Map<String, Object> info = new HashMap<>();
         info.put("personId", person.getId());
         info.put("id", id);
         info.put("firstName", firstName);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsJSONRequestContoller.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsJSONRequestContoller.java
@@ -125,7 +125,7 @@ public class SearchStudentsJSONRequestContoller extends JSONRequestController {
   	  List<Student> studentList2 = studentDAO.listByPerson(person);
   	  StaffMember staffMember = staffMemberDAO.findByPerson(person);
   	  
-  	  if ((!studentList2.isEmpty()) || (staffMember != null)) {
+  	  if (!studentList2.isEmpty() || staffMember != null) {
         String activeStudyProgrammes = "";
         String inactiveStudyProgrammes = "";
   

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsJSONRequestContoller.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/SearchStudentsJSONRequestContoller.java
@@ -125,7 +125,7 @@ public class SearchStudentsJSONRequestContoller extends JSONRequestController {
   	  List<Student> studentList2 = studentDAO.listByPerson(person);
   	  StaffMember staffMember = staffMemberDAO.findByPerson(person);
   	  
-  	  if ((studentList2.size() > 0) || (staffMember != null)) {
+  	  if ((!studentList2.isEmpty()) || (staffMember != null)) {
         String activeStudyProgrammes = "";
         String inactiveStudyProgrammes = "";
   

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/tags/GetAllTagsJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/tags/GetAllTagsJSONRequestController.java
@@ -16,7 +16,7 @@ public class GetAllTagsJSONRequestController extends JSONRequestController {
   public void process(JSONRequestContext requestContext) {
     TagDAO tagDAO = DAOFactory.getInstance().getTagDAO();
     
-    Set<String> tagTexts = new HashSet<String>();
+    Set<String> tagTexts = new HashSet<>();
     
     List<Tag> tags = tagDAO.listAll();
     for (Tag tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/CreateUserJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/CreateUserJSONRequestController.java
@@ -79,7 +79,7 @@ public class CreateUserJSONRequestController extends JSONRequestController {
     String password = requestContext.getString("password1");
     String password2 = requestContext.getString("password2");
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/EditUserJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/EditUserJSONRequestController.java
@@ -87,7 +87,7 @@ public class EditUserJSONRequestController extends JSONRequestController {
         throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
     }
     
-    Set<Tag> tagEntities = new HashSet<Tag>();
+    Set<Tag> tagEntities = new HashSet<>();
     if (!StringUtils.isBlank(tagsText)) {
       List<String> tags = Arrays.asList(tagsText.split("[\\ ,]"));
       for (String tag : tags) {
@@ -109,7 +109,7 @@ public class EditUserJSONRequestController extends JSONRequestController {
     
     // Addresses
     
-    Set<Long> existingAddresses = new HashSet<Long>();
+    Set<Long> existingAddresses = new HashSet<>();
     int addressCount = requestContext.getInteger("addressTable.rowCount");
     for (int i = 0; i < addressCount; i++) {
       String colPrefix = "addressTable." + i;
@@ -145,7 +145,7 @@ public class EditUserJSONRequestController extends JSONRequestController {
 
     // E-mail addresses
     
-    Set<Long> existingEmails = new HashSet<Long>();
+    Set<Long> existingEmails = new HashSet<>();
     int emailCount = requestContext.getInteger("emailTable.rowCount");
     for (int i = 0; i < emailCount; i++) {
       String colPrefix = "emailTable." + i;
@@ -176,7 +176,7 @@ public class EditUserJSONRequestController extends JSONRequestController {
 
     // Phone numbers
     
-    Set<Long> existingPhoneNumbers = new HashSet<Long>();
+    Set<Long> existingPhoneNumbers = new HashSet<>();
     int phoneCount = requestContext.getInteger("phoneTable.rowCount");
     for (int i = 0; i < phoneCount; i++) {
       String colPrefix = "phoneTable." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/SearchUsersJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/SearchUsersJSONRequestController.java
@@ -43,10 +43,10 @@ public class SearchUsersJSONRequestController extends JSONRequestController {
     }
 
     SearchResult<StaffMember> searchResult = userDAO.searchUsers(resultsPerPage, page, text, text, text, text, roles);
-    List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> results = new ArrayList<>();
     List<StaffMember> users = searchResult.getResults();
     for (User user : users) {
-      Map<String, Object> info = new HashMap<String, Object>();
+      Map<String, Object> info = new HashMap<>();
       info.put("id", user.getId());
       info.put("firstName", user.getFirstName());
       info.put("lastName", user.getLastName());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/taglib/ExtensionHookTag.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/taglib/ExtensionHookTag.java
@@ -93,6 +93,6 @@ public class ExtensionHookTag extends TagSupport implements DynamicAttributes {
     this.name = name;
   }
 
-  private Map<String, DynamicAttribute> dynamicAttributes = new HashMap<String, DynamicAttribute>();
+  private Map<String, DynamicAttribute> dynamicAttributes = new HashMap<>();
   private String name;
 }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/BreadcrumbFilter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/BreadcrumbFilter.java
@@ -39,7 +39,7 @@ public class BreadcrumbFilter implements Filter {
   //      }
         RequestController requestController = RequestControllerMapper.getRequestController(controllerName);
   
-        if ((requestController instanceof PyramusViewController) && (requestController instanceof Breadcrumbable)) {
+        if (requestController instanceof PyramusViewController && requestController instanceof Breadcrumbable) {
           BreadcrumbHandler breadcrumbHandler = getBreadcrumbHandler(httpRequest);
           if (request.getParameter("resetbreadcrumb") != null) {
             breadcrumbHandler.clear();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/CSVImporter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/CSVImporter.java
@@ -55,7 +55,7 @@ public class CSVImporter {
             fieldName = firstLine[i];
             value = nextLine[i];
 
-            if ((!StringUtils.isBlank(fieldName)) && (!StringUtils.isBlank(value)))
+            if (!StringUtils.isBlank(fieldName) && !StringUtils.isBlank(value))
               entityHandler.handleValue(fieldName, value, context);
           }
           

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/CSVImporter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/CSVImporter.java
@@ -24,7 +24,7 @@ public class CSVImporter {
   private String[] headerFields;
 
   public List<Object> importDataFromStream(InputStream stream, EntityImportStrategy entityStrategy, Long loggedUserId, Locale locale) throws UnsupportedEncodingException {
-    List<Object> list = new ArrayList<Object>();
+    List<Object> list = new ArrayList<>();
     CSVReader reader = new CSVReader(new InputStreamReader(stream, "UTF-8"));
     
     try {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/DataImporter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/DataImporter.java
@@ -370,7 +370,7 @@ public class DataImporter {
     Method
   }
   
-  private Map<String, Long> storedValues = new HashMap<String, Long>();
+  private Map<String, Long> storedValues = new HashMap<>();
 
   private DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
   

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/DataImporter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/DataImporter.java
@@ -291,7 +291,7 @@ public class DataImporter {
      
       Set<ConstraintViolation<Object>> constraintViolations = systemDAO.validateEntity(pojo);
       
-	  if (constraintViolations.size() == 0) {
+	  if (constraintViolations.isEmpty()) {
 	    systemDAO.persistEntity(pojo);
 	  } else {
 	    String message = "";

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/DataImporter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/DataImporter.java
@@ -128,7 +128,7 @@ public class DataImporter {
           String entityClassName = element.getAttribute("class");
           String className = entityPackageName + '.' + entityClassName;
           
-          if ((entities == null)||entities.contains(className)) {
+          if (entities == null ||entities.contains(className)) {
             Class<?> entityClass = Class.forName(entityPackageName + "." + entityClassName);
          
             NodeIterator entryIterator = XPathAPI.selectNodeIterator(element, "e");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/JSONArrayExtractor.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/JSONArrayExtractor.java
@@ -36,7 +36,7 @@ public class JSONArrayExtractor {
    * that converts no properties, just emits empty <code>JSONObject</code>s.
    */
   public JSONArrayExtractor() {
-    attributeNames = new ArrayList<String>();
+    attributeNames = new ArrayList<>();
   }
   
   /** Creates a new Java collection to <code>JSONArray</code> converter

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/LocaleFilter.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/LocaleFilter.java
@@ -73,7 +73,7 @@ public class LocaleFilter implements Filter {
     }
 
     public Enumeration<Locale> getLocales() {
-      Vector<Locale> v = new Vector<Locale>(1);
+      Vector<Locale> v = new Vector<>(1);
       v.add(getLocale());
       return v.elements();
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportContext.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportContext.java
@@ -74,7 +74,7 @@ public class DataImportContext {
     return loggedUser;
   }
 
-  private Map<Class, Object> entities = new HashMap<Class, Object>();
+  private Map<Class, Object> entities = new HashMap<>();
   private String[] fields;
   private String[] values;
   private User loggedUser;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportContext.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportContext.java
@@ -58,7 +58,7 @@ public class DataImportContext {
   }
   
   public String getFieldValue(String fieldName) {
-    if ((this.fields != null) && (this.values != null) && (this.fields.length == this.values.length)) {
+    if (this.fields != null && this.values != null && this.fields.length == this.values.length) {
       for (int i = 0; i < this.fields.length; i++) {
         if (fieldName.equals(this.fields[i]))
           return this.values[i];

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportStrategyProvider.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportStrategyProvider.java
@@ -68,8 +68,8 @@ public class DataImportStrategyProvider {
     entityFieldHandlers.put(entityStrategy, prov);
   }
 
-  private Map<EntityImportStrategy, EntityFieldHandlerProvider> entityFieldHandlers = new HashMap<EntityImportStrategy, EntityFieldHandlerProvider>();
-  private Map<EntityImportStrategy, EntityHandlingStrategy> entityHandlers = new HashMap<EntityImportStrategy, EntityHandlingStrategy>();
+  private Map<EntityImportStrategy, EntityFieldHandlerProvider> entityFieldHandlers = new HashMap<>();
+  private Map<EntityImportStrategy, EntityHandlingStrategy> entityHandlers = new HashMap<>();
   private static DataImportStrategyProvider _instance;
   
   static {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportUtils.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DataImportUtils.java
@@ -116,7 +116,7 @@ public class DataImportUtils {
   }
 
   
-  private static Map<Class<?>, ValueInterpreter<?>> interpreters = new HashMap<Class<?>, ValueInterpreter<?>>();
+  private static Map<Class<?>, ValueInterpreter<?>> interpreters = new HashMap<>();
 
   static {
     interpreters.put(String.class, new ValueInterpreter<String>() {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DefaultEntityHandlingStrategy.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/DefaultEntityHandlingStrategy.java
@@ -50,7 +50,7 @@ public class DefaultEntityHandlingStrategy implements EntityHandlingStrategy {
       
       Set<ConstraintViolation<Object>> constraintViolations = systemDAO.validateEntity(entity);
 
-      if (constraintViolations.size() == 0) {
+      if (constraintViolations.isEmpty()) {
         systemDAO.persistEntity(entity);
       } else {
         String message = "";

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/EntityFieldHandlerProvider.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/EntityFieldHandlerProvider.java
@@ -13,5 +13,5 @@ public class EntityFieldHandlerProvider {
     return fieldHandlers.get(fieldName);
   }
   
-  private Map<String, FieldHandlingStrategy> fieldHandlers = new HashMap<String, FieldHandlingStrategy>();  
+  private Map<String, FieldHandlingStrategy> fieldHandlers = new HashMap<>();  
 }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/scripting/api/ActivityTypeAPI.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/scripting/api/ActivityTypeAPI.java
@@ -9,7 +9,7 @@ public class ActivityTypeAPI {
   }
   
   public Long createType(String name) {
-    return (DAOFactory.getInstance().getStudentActivityTypeDAO().create(name).getId());
+    return DAOFactory.getInstance().getStudentActivityTypeDAO().create(name).getId();
   }
 
   @SuppressWarnings("unused")

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/scripting/api/PersonAPI.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/scripting/api/PersonAPI.java
@@ -27,7 +27,7 @@ public class PersonAPI {
 
     Person person = personDAO.create(birthday, socialSecurityNumber, sexEntity, basicInfo, secureInfo);
 
-    return (person.getId());
+    return person.getId();
   }
   
   public Long findIdBySocialSecurityNumber(String socialSecurityNumber) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/scripting/api/StudentAPI.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/util/dataimport/scripting/api/StudentAPI.java
@@ -105,7 +105,7 @@ public class StudentAPI {
       emailDAO.create(student.getContactInfo(), emailContactType, true, email);
     }
     
-    return (student.getId());
+    return student.getId();
   }
 
   public void updateStudentPerson(Long studentId, Long personId) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CoursePlannerViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CoursePlannerViewController.java
@@ -45,7 +45,7 @@ public class CoursePlannerViewController extends PyramusViewController implement
     EducationTypeDAO educationTypeDAO = DAOFactory.getInstance().getEducationTypeDAO();    
     EducationSubtypeDAO educationSubtypeDAO = DAOFactory.getInstance().getEducationSubtypeDAO();    
 
-    List<CourseBean> courseBeans = new ArrayList<CoursePlannerViewController.CourseBean>();
+    List<CourseBean> courseBeans = new ArrayList<>();
     for (Course course : courseDAO.listUnarchived()) {
       courseBeans.add(new CourseBean(course));
     }
@@ -102,7 +102,7 @@ public class CoursePlannerViewController extends PyramusViewController implement
     }
     
     public Set<Long> getEducationTypes() {
-      Set<Long> result = new HashSet<Long>();
+      Set<Long> result = new HashSet<>();
       
       List<CourseEducationType> courseEducationTypes = course.getCourseEducationTypes();
       for (CourseEducationType courseEducationType : courseEducationTypes) {
@@ -113,7 +113,7 @@ public class CoursePlannerViewController extends PyramusViewController implement
     }
     
     public Set<Long> getEducationSubtypes() {
-      Set<Long> result = new HashSet<Long>();
+      Set<Long> result = new HashSet<>();
       
       List<CourseEducationType> courseEducationTypes = course.getCourseEducationTypes();
       for (CourseEducationType courseEducationType : courseEducationTypes) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CreateCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CreateCourseViewController.java
@@ -109,7 +109,7 @@ public class CreateCourseViewController extends PyramusViewController implements
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (subjectsOfType.size() > 0)) {
+      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CreateCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CreateCourseViewController.java
@@ -80,7 +80,7 @@ public class CreateCourseViewController extends PyramusViewController implements
     List<EducationType> educationTypes = educationTypeDAO.listUnarchived();
     Collections.sort(educationTypes, new StringAttributeComparator("getName"));
     pageRequestContext.getRequest().setAttribute("educationTypes", educationTypes);
-    Map<String, Boolean> enabledEducationTypes = new HashMap<String, Boolean>();
+    Map<String, Boolean> enabledEducationTypes = new HashMap<>();
     for (CourseEducationType courseEducationType : module.getCourseEducationTypes()) {
       for (CourseEducationSubtype moduleEducationSubtype : courseEducationType.getCourseEducationSubtypes()) {
         enabledEducationTypes.put(courseEducationType.getEducationType().getId() + "."
@@ -104,7 +104,7 @@ public class CreateCourseViewController extends PyramusViewController implements
     List<ModuleComponent> moduleComponents = moduleComponentDAO.listByModule(module);
     
     // Subjects
-    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<Long, List<Subject>>();
+    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<>();
     List<Subject> subjectsByNoEducationType = subjectDAO.listByEducationType(null);
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CreateCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/CreateCourseViewController.java
@@ -109,7 +109,7 @@ public class CreateCourseViewController extends PyramusViewController implements
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
+      if (subjectsOfType != null && !subjectsOfType.isEmpty()) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/EditCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/EditCourseViewController.java
@@ -87,7 +87,7 @@ public class EditCourseViewController extends PyramusViewController implements B
     List<EducationType> educationTypes = educationTypeDAO.listUnarchived();
     Collections.sort(educationTypes, new StringAttributeComparator("getName"));
     pageRequestContext.getRequest().setAttribute("educationTypes", educationTypes);
-    Map<String, Boolean> enabledEducationTypes = new HashMap<String, Boolean>();
+    Map<String, Boolean> enabledEducationTypes = new HashMap<>();
     for (CourseEducationType courseEducationType : course.getCourseEducationTypes()) {
       for (CourseEducationSubtype courseEducationSubtype : courseEducationType.getCourseEducationSubtypes()) {
         enabledEducationTypes.put(courseEducationType.getEducationType().getId() + "."
@@ -133,14 +133,14 @@ public class EditCourseViewController extends PyramusViewController implements B
     
     // course students students
     
-    Map<Long, List<Student>> courseStudentsStudents = new HashMap<Long, List<Student>>();
+    Map<Long, List<Student>> courseStudentsStudents = new HashMap<>();
     
     for (CourseStudent courseStudent : courseStudents) {
       courseStudentsStudents.put(courseStudent.getId(), studentDAO.listByPerson(courseStudent.getStudent().getPerson()));
     }
     
     // Subjects
-    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<Long, List<Subject>>();
+    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<>();
     List<Subject> subjectsByNoEducationType = subjectDAO.listByEducationType(null);
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/EditCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/EditCourseViewController.java
@@ -145,7 +145,7 @@ public class EditCourseViewController extends PyramusViewController implements B
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (subjectsOfType.size() > 0)) {
+      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/EditCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/EditCourseViewController.java
@@ -145,7 +145,7 @@ public class EditCourseViewController extends PyramusViewController implements B
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
+      if (subjectsOfType != null && !subjectsOfType.isEmpty()) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/ManageCourseAssessmentsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/ManageCourseAssessmentsViewController.java
@@ -62,8 +62,8 @@ public class ManageCourseAssessmentsViewController extends PyramusViewController
       }
     });
     
-    Map<Long, CourseAssessment> courseAssessments = new HashMap<Long, CourseAssessment>();
-    Map<Long, String> verbalAssessments = new HashMap<Long, String>();
+    Map<Long, CourseAssessment> courseAssessments = new HashMap<>();
+    Map<Long, String> verbalAssessments = new HashMap<>();
 
     Iterator<CourseStudent> students = courseStudents.iterator();
     while (students.hasNext()) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/SearchCoursesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/SearchCoursesViewController.java
@@ -33,11 +33,11 @@ public class SearchCoursesViewController extends PyramusViewController implement
     Collections.sort(educationTypes, new StringAttributeComparator("getName"));
 
     // Subjects
-    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<Long, List<Subject>>();
+    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<>();
     List<Subject> subjectsByNoEducationType = subjectDAO.listByEducationType(null);
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     
-    Map<Long, List<EducationSubtype>> educationSubtypesByEduType = new HashMap<Long, List<EducationSubtype>>();
+    Map<Long, List<EducationSubtype>> educationSubtypesByEduType = new HashMap<>();
     
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/SearchCoursesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/SearchCoursesViewController.java
@@ -41,7 +41,7 @@ public class SearchCoursesViewController extends PyramusViewController implement
     
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
+      if (subjectsOfType != null && !subjectsOfType.isEmpty()) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/SearchCoursesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/SearchCoursesViewController.java
@@ -41,7 +41,7 @@ public class SearchCoursesViewController extends PyramusViewController implement
     
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (subjectsOfType.size() > 0)) {
+      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/ViewCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/ViewCourseViewController.java
@@ -105,7 +105,7 @@ public class ViewCourseViewController extends PyramusViewController implements B
         }
       });
 
-      if (courseAssessmentRequestsByCourseStudent.size() > 0) {
+      if (!courseAssessmentRequestsByCourseStudent.isEmpty()) {
         courseAssessmentRequests.put(courseStudent.getId(), courseAssessmentRequestsByCourseStudent.get(0));
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/ViewCourseViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/courses/ViewCourseViewController.java
@@ -55,7 +55,7 @@ public class ViewCourseViewController extends PyramusViewController implements B
     Course course = courseDAO.findById(pageRequestContext.getLong("course"));
     pageRequestContext.getRequest().setAttribute("course", course);
 
-    Map<Long, CourseAssessmentRequest> courseAssessmentRequests = new HashMap<Long, CourseAssessmentRequest>();
+    Map<Long, CourseAssessmentRequest> courseAssessmentRequests = new HashMap<>();
     
     List<CourseStudent> courseStudents = courseStudentDAO.listByCourse(course);
     Collections.sort(courseStudents, new Comparator<CourseStudent>() {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/CreateModuleViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/CreateModuleViewController.java
@@ -55,7 +55,7 @@ public class CreateModuleViewController extends PyramusViewController implements
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (subjectsOfType.size() > 0)) {
+      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/CreateModuleViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/CreateModuleViewController.java
@@ -55,7 +55,7 @@ public class CreateModuleViewController extends PyramusViewController implements
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
+      if (subjectsOfType != null && !subjectsOfType.isEmpty()) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/CreateModuleViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/CreateModuleViewController.java
@@ -50,7 +50,7 @@ public class CreateModuleViewController extends PyramusViewController implements
     Collections.sort(educationTypes, new StringAttributeComparator("getName"));
 
     // Subjects
-    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<Long, List<Subject>>();
+    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<>();
     List<Subject> subjectsByNoEducationType = subjectDAO.listByEducationType(null);
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     for (EducationType educationType : educationTypes) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/EditModuleViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/EditModuleViewController.java
@@ -97,7 +97,7 @@ public class EditModuleViewController extends PyramusViewController implements B
     
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (subjectsOfType.size() > 0)) {
+      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/EditModuleViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/EditModuleViewController.java
@@ -97,7 +97,7 @@ public class EditModuleViewController extends PyramusViewController implements B
     
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
+      if (subjectsOfType != null && !subjectsOfType.isEmpty()) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/EditModuleViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/EditModuleViewController.java
@@ -82,7 +82,7 @@ public class EditModuleViewController extends PyramusViewController implements B
     Collections.sort(educationTypes, new StringAttributeComparator("getName"));
 
     pageRequestContext.getRequest().setAttribute("educationTypes", educationTypes);
-    Map<String, Boolean> enabledEducationTypes = new HashMap<String, Boolean>();
+    Map<String, Boolean> enabledEducationTypes = new HashMap<>();
     for (CourseEducationType courseEducationType : module.getCourseEducationTypes()) {
       for (CourseEducationSubtype moduleEducationSubtype : courseEducationType.getCourseEducationSubtypes()) {
         enabledEducationTypes.put(courseEducationType.getEducationType().getId() + "."
@@ -91,7 +91,7 @@ public class EditModuleViewController extends PyramusViewController implements B
     }
     
     // Subjects
-    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<Long, List<Subject>>();
+    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<>();
     List<Subject> subjectsByNoEducationType = subjectDAO.listByEducationType(null);
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/SearchModulesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/SearchModulesViewController.java
@@ -38,7 +38,7 @@ public class SearchModulesViewController extends PyramusViewController implement
 
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
+      if (subjectsOfType != null && !subjectsOfType.isEmpty()) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/SearchModulesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/SearchModulesViewController.java
@@ -30,11 +30,11 @@ public class SearchModulesViewController extends PyramusViewController implement
     List<EducationType> educationTypes = educationTypeDAO.listUnarchived();
     Collections.sort(educationTypes, new StringAttributeComparator("getName"));
 
-    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<Long, List<Subject>>();
+    Map<Long, List<Subject>> subjectsByEducationType = new HashMap<>();
     List<Subject> subjectsByNoEducationType = subjectDAO.listByEducationType(null);
     Collections.sort(subjectsByNoEducationType, new StringAttributeComparator("getName"));
     
-    Map<Long, List<EducationSubtype>> educationSubtypesByEduType = new HashMap<Long, List<EducationSubtype>>();
+    Map<Long, List<EducationSubtype>> educationSubtypesByEduType = new HashMap<>();
 
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/SearchModulesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/modules/SearchModulesViewController.java
@@ -38,7 +38,7 @@ public class SearchModulesViewController extends PyramusViewController implement
 
     for (EducationType educationType : educationTypes) {
       List<Subject> subjectsOfType = subjectDAO.listByEducationType(educationType);
-      if ((subjectsOfType != null) && (subjectsOfType.size() > 0)) {
+      if ((subjectsOfType != null) && (!subjectsOfType.isEmpty())) {
         Collections.sort(subjectsOfType, new StringAttributeComparator("getName"));
         subjectsByEducationType.put(educationType.getId(), subjectsOfType);
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/EditStudentProjectViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/EditStudentProjectViewController.java
@@ -263,7 +263,7 @@ public class EditStudentProjectViewController extends PyramusViewController impl
       courseStudentsJSON.add(obj);
     }
     
-    Map<Long, String> verbalAssessments = new HashMap<Long, String>();
+    Map<Long, String> verbalAssessments = new HashMap<>();
 
     for (ProjectAssessment pAss : assessments) {
       // Shortened descriptions

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/EditStudentProjectViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/EditStudentProjectViewController.java
@@ -89,11 +89,11 @@ public class EditStudentProjectViewController extends PyramusViewController impl
     for (CreditLink creditLink : allStudentCreditLinks) {
       switch (creditLink.getCredit().getCreditType()) {
         case CourseAssessment:
-          allStudentCourseAssessments.add(((CourseAssessment) creditLink.getCredit()));
+          allStudentCourseAssessments.add((CourseAssessment) creditLink.getCredit());
         break;
 
         case TransferCredit:
-          allStudentTransferCredits.add(((TransferCredit) creditLink.getCredit()));
+          allStudentTransferCredits.add((TransferCredit) creditLink.getCredit());
         break;
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/SearchStudentProjectModuleCoursesDialogViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/SearchStudentProjectModuleCoursesDialogViewController.java
@@ -83,7 +83,7 @@ public class SearchStudentProjectModuleCoursesDialogViewController extends Pyram
       }
     }));
     
-    List<StudentProjectModuleCourseBean> studentProjectModuleCourses = new ArrayList<StudentProjectModuleCourseBean>();
+    List<StudentProjectModuleCourseBean> studentProjectModuleCourses = new ArrayList<>();
     int coursesInTimeFrame = 0; 
     for (Course course : courses) {
       boolean withinTimeFrame = false;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/SearchStudentProjectModuleCoursesDialogViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/SearchStudentProjectModuleCoursesDialogViewController.java
@@ -108,7 +108,7 @@ public class SearchStudentProjectModuleCoursesDialogViewController extends Pyram
     
     String message;
     
-    if (courses.size() > 0) {
+    if (!courses.isEmpty()) {
       message = Messages.getInstance().getText(pageRequestContext.getRequest().getLocale(), "projects.searchStudentProjectModuleCoursesDialog.coursesFound", new Object[] {
         courses.size(), coursesInTimeFrame
       });

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/ViewProjectViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/projects/ViewProjectViewController.java
@@ -70,7 +70,7 @@ public class ViewProjectViewController extends PyramusViewController implements 
     Collections.sort(educationalTimeUnits, new StringAttributeComparator("getName"));
 
     List<StudentProject> studentProjectsByProject = studentProjectDAO.listByProject(project);
-    List<StudentProjectBean> studentProjectBeans = new ArrayList<StudentProjectBean>();
+    List<StudentProjectBean> studentProjectBeans = new ArrayList<>();
     Collections.sort(studentProjectsByProject, new Comparator<StudentProject>() {
       @Override
       public int compare(StudentProject o1, StudentProject o2) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/EditReportViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/EditReportViewController.java
@@ -53,11 +53,11 @@ public class EditReportViewController extends PyramusViewController implements B
       }
     });
     
-    Map<String, Boolean> selectedContexts = new HashMap<String, Boolean>();
+    Map<String, Boolean> selectedContexts = new HashMap<>();
     for (ReportContext context : reportContexts)
       selectedContexts.put(context.getContext().toString(), Boolean.TRUE);
 
-    List<String> contextTypes = new ArrayList<String>();
+    List<String> contextTypes = new ArrayList<>();
     for (ReportContextType contextType : ReportContextType.values())
       contextTypes.add(contextType.toString());
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/ViewReportContentsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/ViewReportContentsViewController.java
@@ -112,7 +112,7 @@ public class ViewReportContentsViewController extends PyramusViewController impl
     return Messages.getInstance().getText(locale, "reports.viewReport.pageTitle");
   }
 
-  private static Set<String> reservedParameters = new HashSet<String>();
+  private static Set<String> reservedParameters = new HashSet<>();
   
   static {
     reservedParameters.add("reportId");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/ViewReportViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/ViewReportViewController.java
@@ -43,7 +43,7 @@ public class ViewReportViewController extends PyramusViewController implements B
     ReportContextDAO reportContextDAO = DAOFactory.getInstance().getReportContextDAO();
     
     List<ReportContext> contexts = reportContextDAO.listByReport(report);
-    List<String> contextStrs = new ArrayList<String>();
+    List<String> contextStrs = new ArrayList<>();
     
     for (ReportContext ctx : contexts) {
       contextStrs.add(ctx.getContext().toString());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ManageChangeLogViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ManageChangeLogViewController.java
@@ -59,7 +59,7 @@ public class ManageChangeLogViewController extends PyramusFormViewController {
           case BASIC:
           case ONE_TO_ONE:
           case MANY_TO_ONE:
-            if ((!attribute.equals(idAttribute)) && !this.isVersion(entityClass, attribute)) {
+            if (!attribute.equals(idAttribute) && !this.isVersion(entityClass, attribute)) {
               String propertyName = attribute.getName();
               TrackedEntityProperty trackedEntityProperty = trackedEntityPropertyDAO.findByEntityAndProperty(entityName, propertyName);
               ManageChangeLogViewEntityPropertyBean propertyBean = new ManageChangeLogViewEntityPropertyBean(propertyName,

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ManageChangeLogViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ManageChangeLogViewController.java
@@ -42,12 +42,12 @@ public class ManageChangeLogViewController extends PyramusFormViewController {
     SystemDAO systemDAO = DAOFactory.getInstance().getSystemDAO();
     TrackedEntityPropertyDAO trackedEntityPropertyDAO = DAOFactory.getInstance().getTrackedEntityPropertyDAO();
 
-    List<ManageChangeLogViewEntityBean> entityBeans = new ArrayList<ManageChangeLogViewEntityBean>();
-    List<EntityType<?>> entities = new ArrayList<EntityType<?>>(systemDAO.getEntities());
+    List<ManageChangeLogViewEntityBean> entityBeans = new ArrayList<>();
+    List<EntityType<?>> entities = new ArrayList<>(systemDAO.getEntities());
     for (EntityType<?> entity : entities) {
       if (!isAbstractSuperclass(entity) && !isChangeLogEntity(entity)) {
 
-        List<ManageChangeLogViewEntityPropertyBean> properties = new ArrayList<ManageChangeLogViewEntityPropertyBean>();
+        List<ManageChangeLogViewEntityPropertyBean> properties = new ArrayList<>();
 
         String entityName = entity.getJavaType().getCanonicalName();
         Class<?> entityClass = entity.getJavaType();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ManageChangeLogViewEntityBean.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ManageChangeLogViewEntityBean.java
@@ -25,5 +25,5 @@ public class ManageChangeLogViewEntityBean {
   
   private String displayName;
   private String name;
-  private List<ManageChangeLogViewEntityPropertyBean> properties = new ArrayList<ManageChangeLogViewEntityPropertyBean>();
+  private List<ManageChangeLogViewEntityPropertyBean> properties = new ArrayList<>();
 }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/TimeUnitsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/TimeUnitsViewController.java
@@ -35,7 +35,7 @@ public class TimeUnitsViewController extends PyramusViewController implements Br
     DefaultsDAO defaultsDAO = DAOFactory.getInstance().getDefaultsDAO();
     
     final EducationalTimeUnit baseTimeUnit = defaultsDAO.getDefaults().getBaseTimeUnit();
-    List<EducationalTimeUnit> timeUnits = new ArrayList<EducationalTimeUnit>(educationalTimeUnitDAO.listUnarchived());
+    List<EducationalTimeUnit> timeUnits = new ArrayList<>(educationalTimeUnitDAO.listUnarchived());
     
 
     Collections.sort(timeUnits, new Comparator<EducationalTimeUnit>() {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ViewSchoolViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/settings/ViewSchoolViewController.java
@@ -99,7 +99,7 @@ public class ViewSchoolViewController extends PyramusViewController implements B
     for (int i=0; i<schoolUserEditableVariableKeys.size(); i++) {
       JSONObject jsonVariableKey = jsonVariableKeys.getJSONObject(i);
 
-      Map<String,String> variables = new HashMap<String, String>();
+      Map<String,String> variables = new HashMap<>();
       for (SchoolVariable schoolVariable : schoolVariableDAO.listBySchool(school)) {
         variables.put(schoolVariable.getKey().getVariableKey(), schoolVariable.getValue());
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/studentfiles/UploadReportDialogViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/studentfiles/UploadReportDialogViewController.java
@@ -78,7 +78,7 @@ public class UploadReportDialogViewController extends PyramusViewController {
     return new UserRole[] { UserRole.MANAGER, UserRole.ADMINISTRATOR };
   }
 
-  private static Set<String> reservedParameters = new HashSet<String>();
+  private static Set<String> reservedParameters = new HashSet<>();
   
   static {
     reservedParameters.add("reportId");

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/EditStudentGroupViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/EditStudentGroupViewController.java
@@ -47,7 +47,7 @@ public class EditStudentGroupViewController extends PyramusViewController implem
     StudentGroup studentGroup = studentGroupDAO.findById(NumberUtils.createLong(pageRequestContext.getRequest().getParameter("studentgroup")));
     pageRequestContext.getRequest().setAttribute("studentGroup", studentGroup);
 
-    List<StudentGroupStudent> studentGroupStudents = new ArrayList<StudentGroupStudent>(studentGroup.getStudents());
+    List<StudentGroupStudent> studentGroupStudents = new ArrayList<>(studentGroup.getStudents());
     Collections.sort(studentGroupStudents, new Comparator<StudentGroupStudent>() {
       @Override
       public int compare(StudentGroupStudent o1, StudentGroupStudent o2) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/EditStudentViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/EditStudentViewController.java
@@ -119,8 +119,8 @@ public class EditStudentViewController extends PyramusViewController implements 
       }
     });
     
-    Map<Long, String> studentTags = new HashMap<Long, String>();
-    Map<Long, Boolean> studentHasCredits = new HashMap<Long, Boolean>();
+    Map<Long, String> studentTags = new HashMap<>();
+    Map<Long, Boolean> studentHasCredits = new HashMap<>();
 
     List<UserVariableKey> userVariableKeys = userVariableKeyDAO.listByUserEditable(Boolean.TRUE);
     Collections.sort(userVariableKeys, new StringAttributeComparator("getVariableName"));

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ImportStudentCreditsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ImportStudentCreditsViewController.java
@@ -185,7 +185,7 @@ public class ImportStudentCreditsViewController extends PyramusViewController im
         
         arr.add(obj);
       }
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         courseAssessmentsByStudent.put(student.getId(), arr);
       
       arr = new JSONArray();
@@ -211,7 +211,7 @@ public class ImportStudentCreditsViewController extends PyramusViewController im
         
         arr.add(obj);
       }
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         transferCreditsByStudent.put(student.getId(), arr);
       
       
@@ -269,7 +269,7 @@ public class ImportStudentCreditsViewController extends PyramusViewController im
         arr.add(obj);
       }
       
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         linkedCourseAssessments.put(student.getId(), arr);
       
       /**
@@ -324,7 +324,7 @@ public class ImportStudentCreditsViewController extends PyramusViewController im
         arr.add(obj);
       }
       
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         linkedTransferCredits.put(student.getId(), arr);
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ImportStudentCreditsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ImportStudentCreditsViewController.java
@@ -94,8 +94,8 @@ public class ImportStudentCreditsViewController extends PyramusViewController im
     });
     
     
-    List<Long> linkedCourseAssessmentIds = new ArrayList<Long>();
-    List<Long> linkedTransferCreditIds = new ArrayList<Long>();
+    List<Long> linkedCourseAssessmentIds = new ArrayList<>();
+    List<Long> linkedTransferCreditIds = new ArrayList<>();
     
     List<CreditLink> creditLinks = creditLinkDAO.listByStudent(baseStudent);
     for (CreditLink creditLink : creditLinks) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ManageStudentContactEntriesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ManageStudentContactEntriesViewController.java
@@ -97,8 +97,8 @@ public class ManageStudentContactEntriesViewController extends PyramusViewContro
       }
     });
 
-    Map<Long, List<StudentContactLogEntry>> contactEntries = new HashMap<Long, List<StudentContactLogEntry>>();
-    final Map<Long, List<StudentContactLogEntryComment>> contactEntryComments = new HashMap<Long, List<StudentContactLogEntryComment>>();
+    Map<Long, List<StudentContactLogEntry>> contactEntries = new HashMap<>();
+    final Map<Long, List<StudentContactLogEntryComment>> contactEntryComments = new HashMap<>();
     
     for (int i = 0; i < students.size(); i++) {
     	Student student = students.get(i);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ManageStudentGroupContactEntriesViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ManageStudentGroupContactEntriesViewController.java
@@ -58,7 +58,7 @@ public class ManageStudentGroupContactEntriesViewController extends PyramusViewC
     
     pageRequestContext.getRequest().setAttribute("studentGroup", studentGroup);
 
-    final Map<Long, List<StudentGroupContactLogEntryComment>> contactEntryComments = new HashMap<Long, List<StudentGroupContactLogEntryComment>>();
+    final Map<Long, List<StudentGroupContactLogEntryComment>> contactEntryComments = new HashMap<>();
     List<StudentGroupContactLogEntry> contactLogEntries = logEntryDAO.listByStudentGroup(studentGroup);
 
     // Populate comments for each entry to lists

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentGroupViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentGroupViewController.java
@@ -43,7 +43,7 @@ public class ViewStudentGroupViewController extends PyramusViewController implem
     StudentGroup studentGroup = studentGroupDAO.findById(pageRequestContext.getLong("studentgroup"));
     pageRequestContext.getRequest().setAttribute("studentGroup", studentGroup);
     
-    List<StudentGroupStudent> studentGroupStudents = new ArrayList<StudentGroupStudent>(studentGroup.getStudents());
+    List<StudentGroupStudent> studentGroupStudents = new ArrayList<>(studentGroup.getStudents());
     Collections.sort(studentGroupStudents, new Comparator<StudentGroupStudent>() {
       @Override
       public int compare(StudentGroupStudent o1, StudentGroupStudent o2) {
@@ -54,7 +54,7 @@ public class ViewStudentGroupViewController extends PyramusViewController implem
       }
     });
 
-    final Map<Long, List<StudentGroupContactLogEntryComment>> contactEntryComments = new HashMap<Long, List<StudentGroupContactLogEntryComment>>();
+    final Map<Long, List<StudentGroupContactLogEntryComment>> contactEntryComments = new HashMap<>();
     List<StudentGroupContactLogEntry> contactLogEntries = contactLogEntryDAO.listByStudentGroup(studentGroup);
     
     // Populate comments for each entry to lists

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentViewController.java
@@ -150,18 +150,18 @@ public class ViewStudentViewController extends PyramusViewController implements 
       }
     });
     
-    Map<Long, Boolean> studentHasImage = new HashMap<Long, Boolean>();
-    Map<Long, List<CourseStudent>> courseStudents = new HashMap<Long, List<CourseStudent>>();
-    Map<Long, List<StudentContactLogEntry>> contactEntries = new HashMap<Long, List<StudentContactLogEntry>>();
-    Map<Long, List<TransferCredit>> transferCredits = new HashMap<Long, List<TransferCredit>>();
-    Map<Long, List<CourseAssessment>> courseAssessments = new HashMap<Long, List<CourseAssessment>>();
-    Map<Long, CourseAssessmentRequest> courseAssessmentRequests = new HashMap<Long, CourseAssessmentRequest>();
-    Map<Long, List<StudentGroup>> studentGroups = new HashMap<Long, List<StudentGroup>>();
-    Map<Long, List<StudentProjectBean>> studentProjects = new HashMap<Long, List<StudentProjectBean>>();
-    Map<Long, CourseAssessment> courseAssessmentsByCourseStudent = new HashMap<Long, CourseAssessment>();
+    Map<Long, Boolean> studentHasImage = new HashMap<>();
+    Map<Long, List<CourseStudent>> courseStudents = new HashMap<>();
+    Map<Long, List<StudentContactLogEntry>> contactEntries = new HashMap<>();
+    Map<Long, List<TransferCredit>> transferCredits = new HashMap<>();
+    Map<Long, List<CourseAssessment>> courseAssessments = new HashMap<>();
+    Map<Long, CourseAssessmentRequest> courseAssessmentRequests = new HashMap<>();
+    Map<Long, List<StudentGroup>> studentGroups = new HashMap<>();
+    Map<Long, List<StudentProjectBean>> studentProjects = new HashMap<>();
+    Map<Long, CourseAssessment> courseAssessmentsByCourseStudent = new HashMap<>();
     // StudentProject.id -> List of module beans
-    Map<Long, List<StudentProjectModuleBean>> studentProjectModules = new HashMap<Long, List<StudentProjectModuleBean>>();
-    final Map<Long, List<StudentContactLogEntryComment>> contactEntryComments = new HashMap<Long, List<StudentContactLogEntryComment>>();
+    Map<Long, List<StudentProjectModuleBean>> studentProjectModules = new HashMap<>();
+    final Map<Long, List<StudentContactLogEntryComment>> contactEntryComments = new HashMap<>();
     
     JSONObject linkedCourseAssessments = new JSONObject();
     JSONObject linkedTransferCredits = new JSONObject();
@@ -457,14 +457,14 @@ public class ViewStudentViewController extends PyramusViewController implements 
        * Project beans setup
        */
       List<StudentProject> studentsStudentProjects = studentProjectDAO.listByStudent(student);
-      List<StudentProjectBean> studentProjectBeans = new ArrayList<StudentProjectBean>();
+      List<StudentProjectBean> studentProjectBeans = new ArrayList<>();
       for (StudentProject studentProject : studentsStudentProjects) {
         int mandatoryModuleCount = 0;
         int optionalModuleCount = 0;
         int passedMandatoryModuleCount = 0;
         int passedOptionalModuleCount = 0;
         
-        List<StudentProjectModuleBean> studentProjectModuleBeans = new ArrayList<StudentProjectModuleBean>();
+        List<StudentProjectModuleBean> studentProjectModuleBeans = new ArrayList<>();
         
         /**
          * Go through project modules to
@@ -492,8 +492,8 @@ public class ViewStudentViewController extends PyramusViewController implements 
         for (StudentProjectModule studentProjectModule : studentProject.getStudentProjectModules()) {
           boolean hasPassingGrade = false;
 
-          List<CourseStudent> projectCourseCourseStudentList = new ArrayList<CourseStudent>();
-          List<TransferCredit> projectCourseTransferCreditList = new ArrayList<TransferCredit>();
+          List<CourseStudent> projectCourseCourseStudentList = new ArrayList<>();
+          List<TransferCredit> projectCourseTransferCreditList = new ArrayList<>();
 
           // Find out if there is a course that has passing grade for the module
           

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentViewController.java
@@ -220,7 +220,7 @@ public class ViewStudentViewController extends PyramusViewController implements 
           }
         });
 
-        if (courseAssessmentRequestsByCourseStudent.size() > 0) {
+        if (!courseAssessmentRequestsByCourseStudent.isEmpty()) {
           courseAssessmentRequests.put(courseStudent.getId(), courseAssessmentRequestsByCourseStudent.get(0));
         }
     	}
@@ -399,7 +399,7 @@ public class ViewStudentViewController extends PyramusViewController implements 
         arr.add(obj);
       }
       
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         linkedCourseAssessments.put(student.getId(), arr);
       
       /**
@@ -450,7 +450,7 @@ public class ViewStudentViewController extends PyramusViewController implements 
         arr.add(obj);
       }
       
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         linkedTransferCredits.put(student.getId(), arr);
       
       /**
@@ -559,7 +559,7 @@ public class ViewStudentViewController extends PyramusViewController implements 
         obj.put("lastModified", file.getLastModified().getTime());
         arr.add(obj);
       }
-      if (arr.size() > 0)
+      if (!arr.isEmpty())
         studentFiles.put(student.getId(), arr);
       
       // Student Image

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportCSVViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportCSVViewController.java
@@ -35,7 +35,7 @@ public class ImportCSVViewController extends PyramusFormViewController {
       throw new SmvcRuntimeException(e);
     }
     
-    List<Object> entityList = new ArrayList<Object>();
+    List<Object> entityList = new ArrayList<>();
     for (int i = 0; i < list.size(); i++) {
       Object o = list.get(i);
       

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportCSVViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportCSVViewController.java
@@ -39,7 +39,7 @@ public class ImportCSVViewController extends PyramusFormViewController {
     for (int i = 0; i < list.size(); i++) {
       Object o = list.get(i);
       
-      if ((o != null) && (o.getClass().equals(entityClass)))
+      if (o != null && o.getClass().equals(entityClass))
         entityList.add(o);
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportReportViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportReportViewController.java
@@ -53,7 +53,7 @@ public class ImportReportViewController extends PyramusFormViewController {
     Collections.sort(reports, new StringAttributeComparator("getName"));
     
     JSONArray contextTypesJSON = new JSONArray();
-    List<String> contextTypes = new ArrayList<String>();
+    List<String> contextTypes = new ArrayList<>();
     for (ReportContextType contextType : ReportContextType.values()) {
       contextTypes.add(contextType.toString());
       contextTypesJSON.add(contextType.toString());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportReportViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ImportReportViewController.java
@@ -204,9 +204,9 @@ public class ImportReportViewController extends PyramusFormViewController {
       
       boolean selected = requestContext.getBoolean("context." + contextType.toString());
       
-      if ((selected) && (context == null))
+      if (selected && context == null)
         reportContextDAO.create(report, contextType);
-      else if ((!selected) && (context != null))
+      else if (!selected && context != null)
         reportContextDAO.delete(context);
     }
   }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/PluginsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/PluginsViewController.java
@@ -25,7 +25,7 @@ public class PluginsViewController extends PyramusFormViewController {
 
     List<PluginRepository> pluginRepositories = pluginRepositoryDAO.listAll();
     List<Plugin> plugins = pluginDAO.listAll();
-    List<PluginBean> pluginBeans = new ArrayList<PluginsViewController.PluginBean>(plugins.size());
+    List<PluginBean> pluginBeans = new ArrayList<>(plugins.size());
     for (Plugin plugin : plugins) {
       String status = "";
       boolean loaded = pluginManager.isLoaded(plugin.getGroupId(), plugin.getArtifactId(), plugin.getVersion());

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ReindexHibernateObjects.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/ReindexHibernateObjects.java
@@ -32,7 +32,7 @@ public class ReindexHibernateObjects extends PyramusViewController {
         session.setAttribute("pendingIndexingTasks", pendingIndexingTasks);
         redirectBack = true;
       } else {
-        if (pendingIndexingTasks.size() != 0) {
+        if (!pendingIndexingTasks.isEmpty()) {
           indexClass = pendingIndexingTasks.get(0);
           pendingIndexingTasks.remove(0);
           session.setAttribute("pendingIndexingTasks", pendingIndexingTasks);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/SystemSettingsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/SystemSettingsViewController.java
@@ -25,7 +25,7 @@ public class SystemSettingsViewController extends PyramusFormViewController {
     SettingDAO settingDAO = DAOFactory.getInstance().getSettingDAO();
     SettingKeyDAO settingKeyDAO = DAOFactory.getInstance().getSettingKeyDAO();
     
-    Map<String, String> settings = new HashMap<String, String>();
+    Map<String, String> settings = new HashMap<>();
     List<SettingKey> settingKeys = settingKeyDAO.listAll();
     for (SettingKey settingKey : settingKeys) {
       Setting setting = settingDAO.findByKey(settingKey);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/setupwizard/AdminPasswordSetupWizardViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/setupwizard/AdminPasswordSetupWizardViewController.java
@@ -50,14 +50,14 @@ public class AdminPasswordSetupWizardViewController extends SetupWizardControlle
   @Override
   public boolean isInitialized(PageRequestContext requestContext) throws SetupWizardException {
     StaffMemberDAO userDAO = DAOFactory.getInstance().getStaffMemberDAO();
-    return userDAO.listAll().size() > 0;
+    return !userDAO.listAll().isEmpty();
   }
 
   @Override
   public UserRole[] getAllowedRoles() {
     StaffMemberDAO userDAO = DAOFactory.getInstance().getStaffMemberDAO();
     List<StaffMember> users = userDAO.listAll();
-    if (users.size() == 0) {
+    if (users.isEmpty()) {
       return new UserRole[] { UserRole.EVERYONE }; 
     } else {
       return super.getAllowedRoles();

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/setupwizard/StudyEndReasonsSetupWizardViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/system/setupwizard/StudyEndReasonsSetupWizardViewController.java
@@ -26,8 +26,8 @@ public class StudyEndReasonsSetupWizardViewController extends SetupWizardControl
     StudentStudyEndReasonDAO studentStudyEndReasonDAO = DAOFactory.getInstance().getStudentStudyEndReasonDAO();    
 
     int rowCount = requestContext.getInteger("studyEndReasonsTable.rowCount");
-    Map<String, StudentStudyEndReason> reasons = new HashMap<String, StudentStudyEndReason>();
-    Map<String, String> parents = new HashMap<String, String>();
+    Map<String, StudentStudyEndReason> reasons = new HashMap<>();
+    Map<String, String> parents = new HashMap<>();
 
     for (int i = 0; i < rowCount; i++) {
       String colPrefix = "studyEndReasonsTable." + i;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/webhooks/WebhookDatas.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/webhooks/WebhookDatas.java
@@ -35,7 +35,7 @@ public class WebhookDatas {
   }
   
   public List<Long> retrieveUpdatedStaffMemberIds() {
-    List<Long> result = new ArrayList<Long>(updatedStaffMemberIds);
+    List<Long> result = new ArrayList<>(updatedStaffMemberIds);
     updatedStaffMemberIds.clear();
     return result;
   }
@@ -49,7 +49,7 @@ public class WebhookDatas {
   }
   
   public List<Long> retrieveUpdatedStudentIds() {
-    List<Long> result = new ArrayList<Long>(updatedStudentIds);
+    List<Long> result = new ArrayList<>(updatedStudentIds);
     updatedStudentIds.clear();
     return result;
   }
@@ -63,7 +63,7 @@ public class WebhookDatas {
   }
   
   public List<Long> retrieveUpdatedCourseIds() {
-    List<Long> result = new ArrayList<Long>(updatedCourseIds);
+    List<Long> result = new ArrayList<>(updatedCourseIds);
     updatedCourseIds.clear();
     return result;
   }
@@ -80,7 +80,7 @@ public class WebhookDatas {
   }
   
   public List<Long> retrieveUpdatedCourseStudentIds() {
-    List<Long> result = new ArrayList<Long>(updatedCourseStudentIds);
+    List<Long> result = new ArrayList<>(updatedCourseStudentIds);
     updatedCourseStudentIds.clear();
     return result;
   }
@@ -111,7 +111,7 @@ public class WebhookDatas {
   }
   
   public List<Long> retrieveUpdatedCourseStaffMemberIds() {
-    List<Long> result = new ArrayList<Long>(updatedCourseStaffMemberIds);
+    List<Long> result = new ArrayList<>(updatedCourseStaffMemberIds);
     updatedCourseStaffMemberIds.clear();
     return result;
   }

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/AbstractRESTPermissionsTest.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/AbstractRESTPermissionsTest.java
@@ -187,7 +187,7 @@ public abstract class AbstractRESTPermissionsTest extends AbstractIntegrationTes
     // The parameter generator returns a List of
     // arrays. Each array has two elements: { role }.
     
-    List<Object[]> data = new ArrayList<Object[]>();
+    List<Object[]> data = new ArrayList<>();
     
     for (Role role : Role.values()) {
       data.add(new Object[] { 

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/PersonTestsIT.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/PersonTestsIT.java
@@ -227,7 +227,7 @@ public class PersonTestsIT extends AbstractRESTServiceTest {
 
     int person2Id = response.body().jsonPath().getInt("id");
     
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     
     Student student = new Student(null, 
       (long) person1Id, // personId

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/SchoolPermissionsTestsIT.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/SchoolPermissionsTestsIT.java
@@ -33,7 +33,7 @@ public class SchoolPermissionsTestsIT extends AbstractRESTPermissionsTest {
   
   @Test
   public void testPermissionsCreateSchool() throws NoSuchFieldException {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     
     School school = new School(null, "TST", "created", Arrays.asList("tag1", "tag2"), 1l, "additional info", Boolean.FALSE, variables);
     
@@ -69,7 +69,7 @@ public class SchoolPermissionsTestsIT extends AbstractRESTPermissionsTest {
   
   @Test
   public void testPermissionsUpdateSchool() throws NoSuchFieldException {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     
     School school = new School(null, "TST", "notupdated", Arrays.asList("tag1", "tag2"), 1l, "not updated info", Boolean.FALSE, variables);
     
@@ -80,7 +80,7 @@ public class SchoolPermissionsTestsIT extends AbstractRESTPermissionsTest {
       
     Long id = new Long(response.body().jsonPath().getInt("id"));
     try {
-      Map<String, String> updateVariables = new HashMap<String, String>();
+      Map<String, String> updateVariables = new HashMap<>();
 
       School updateSchool = new School(id, "UPD", "updated", Arrays.asList("tag2", "tag3"), 2l, "updated info", Boolean.FALSE, updateVariables);
 

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/SchoolTestsIT.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/SchoolTestsIT.java
@@ -24,7 +24,7 @@ public class SchoolTestsIT extends AbstractRESTServiceTest {
  //FIXME: find out why i break all tests that run after me
   @Test
   public void testCreateSchool() {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     
@@ -85,7 +85,7 @@ public class SchoolTestsIT extends AbstractRESTServiceTest {
   
   @Test
   public void testUpdateSchool() {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     
@@ -108,7 +108,7 @@ public class SchoolTestsIT extends AbstractRESTServiceTest {
       
     Long id = new Long(response.body().jsonPath().getInt("id"));
     try {
-      Map<String, String> updateVariables = new HashMap<String, String>();
+      Map<String, String> updateVariables = new HashMap<>();
       updateVariables.put("TV2", "234");
       updateVariables.put("TV3", "1");
 

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/StudentPermissionsTestsIT.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/StudentPermissionsTestsIT.java
@@ -44,7 +44,7 @@ public class StudentPermissionsTestsIT extends AbstractRESTPermissionsTest {
     
   @Test
   public void testCreateStudent() throws NoSuchFieldException {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     
@@ -118,7 +118,7 @@ public class StudentPermissionsTestsIT extends AbstractRESTPermissionsTest {
   
   @Test
   public void testUpdateStudent() throws NoSuchFieldException {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     
@@ -157,7 +157,7 @@ public class StudentPermissionsTestsIT extends AbstractRESTPermissionsTest {
     
     Long id = new Long(response.body().jsonPath().getInt("id"));
     try {
-      Map<String, String> updateVariables = new HashMap<String, String>();
+      Map<String, String> updateVariables = new HashMap<>();
       updateVariables.put("TV2", "abc");
       updateVariables.put("TV3", "edf");
       
@@ -211,7 +211,7 @@ public class StudentPermissionsTestsIT extends AbstractRESTPermissionsTest {
       
       Long personId = new Long(response.body().jsonPath().getInt("personId"));
       
-      Map<String, String> updateVariables = new HashMap<String, String>();
+      Map<String, String> updateVariables = new HashMap<>();
       updateVariables.put("TV2", "abc");
       updateVariables.put("TV3", "edf");
       
@@ -254,7 +254,7 @@ public class StudentPermissionsTestsIT extends AbstractRESTPermissionsTest {
   
   @Test
   public void testDeleteStudent() throws NoSuchFieldException {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/StudentTestsIT.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/rest/StudentTestsIT.java
@@ -23,7 +23,7 @@ public class StudentTestsIT extends AbstractRESTServiceTest {
   
   @Test
   public void testCreateStudent() {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     
@@ -225,7 +225,7 @@ public class StudentTestsIT extends AbstractRESTServiceTest {
   
   @Test
   public void testUpdateStudent() {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     
@@ -292,7 +292,7 @@ public class StudentTestsIT extends AbstractRESTServiceTest {
     
     Long id = new Long(response.body().jsonPath().getInt("id"));
     try {
-      Map<String, String> updateVariables = new HashMap<String, String>();
+      Map<String, String> updateVariables = new HashMap<>();
       updateVariables.put("TV2", "abc");
       updateVariables.put("TV3", "edf");
       
@@ -366,7 +366,7 @@ public class StudentTestsIT extends AbstractRESTServiceTest {
   
   @Test
   public void testDeleteStudent() {
-    Map<String, String> variables = new HashMap<String, String>();
+    Map<String, String> variables = new HashMap<>();
     variables.put("TV1", "text");
     variables.put("TV2", "123");
     

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/ui/AbstractUITest.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/ui/AbstractUITest.java
@@ -27,7 +27,7 @@ public class AbstractUITest extends AbstractIntegrationTest {
   }
 
   protected void testPageElementsByName(String elementName) {
-    Boolean elementExists = getWebDriver().findElements(By.name(elementName)).size() > 0;
+    Boolean elementExists = !getWebDriver().findElements(By.name(elementName)).isEmpty();
     assertEquals(true, elementExists);
   }
 

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/ui/base/AuthTestsBase.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/ui/base/AuthTestsBase.java
@@ -19,9 +19,9 @@ public class AuthTestsBase extends AbstractUITest {
     getWebDriver().get(getAppUrl(true) + "/users/authorize.page?client_id=854885cf-2284-4b17-b63c-a8b189535f8d&response_type=code&redirect_uri=https%3A%2F%2Fdev.muikku.fi%3A8443%2Flogin%3F_stg%3Drsp#at-auth");
     waitForUrlNotMatches(".*/index.*");
       
-    Boolean authorizeElementExists = getWebDriver().findElements(By.name("authorize")).size() > 0;
+    Boolean authorizeElementExists = !getWebDriver().findElements(By.name("authorize")).isEmpty();
     assertEquals(true, authorizeElementExists);
-    Boolean denyElementExists = getWebDriver().findElements(By.name("deny")).size() > 0;
+    Boolean denyElementExists = !getWebDriver().findElements(By.name("deny")).isEmpty();
     assertEquals(true, denyElementExists);
   }
   

--- a/pyramus/src/test/java/fi/otavanopisto/pyramus/ui/base/StudentTestsBase.java
+++ b/pyramus/src/test/java/fi/otavanopisto/pyramus/ui/base/StudentTestsBase.java
@@ -70,7 +70,7 @@ public class StudentTestsBase extends AbstractUITest {
 //  TODO: No usable name, class or id for this element.
     getWebDriver().findElement(By.cssSelector(".ixTableRow:first-child .ixTableCell:nth-of-type(10) img")).click();
     waitForUrlNotMatches(".*/viewcourse.*");
-    Boolean elementExists = getWebDriver().findElements(By.cssSelector("#studentViewBasicInfoWrapper")).size() > 0;
+    Boolean elementExists = !getWebDriver().findElements(By.cssSelector("#studentViewBasicInfoWrapper")).isEmpty();
     assertEquals(true, elementExists);
   }
 

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/CalendarRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/CalendarRESTService.java
@@ -62,7 +62,7 @@ public class CalendarRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if ((startDate == null) || (endDate == null)) {
+    if (startDate == null || endDate == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -118,7 +118,7 @@ public class CalendarRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if ((startDate == null) || (endDate == null)) {
+    if (startDate == null || endDate == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/CommonRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/CommonRESTService.java
@@ -197,7 +197,7 @@ public class CommonRESTService extends AbstractRESTService {
   @GET
   @RESTPermit (CommonPermissions.FIND_EDUCATIONSUBTYPE)
   public Response findEducationTypeById(@PathParam("EDUCATIONTYPEID") Long educationTypeId, @PathParam ("EDUCATIONSUBTYPEID") Long educationSubtypeId) {
-    if ((educationTypeId == null) || (educationSubtypeId == null)) {
+    if (educationTypeId == null || educationSubtypeId == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -230,7 +230,7 @@ public class CommonRESTService extends AbstractRESTService {
   @PUT
   @RESTPermit (CommonPermissions.UPDATE_EDUCATIONSUBTYPE)
   public Response updateEducationSubtype(@PathParam("EDUCATIONTYPEID") Long educationTypeId, @PathParam ("EDUCATIONSUBTYPEID") Long educationSubtypeId, fi.otavanopisto.pyramus.rest.model.EducationSubtype entity) {
-    if ((educationTypeId == null) || (educationSubtypeId == null)) {
+    if (educationTypeId == null || educationSubtypeId == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -270,7 +270,7 @@ public class CommonRESTService extends AbstractRESTService {
   @DELETE
   @RESTPermit (CommonPermissions.DELETE_EDUCATIONSUBTYPE)
   public Response deleteEducationSubtype(@PathParam("EDUCATIONTYPEID") Long educationTypeId, @PathParam ("EDUCATIONSUBTYPEID") Long educationSubtypeId, @DefaultValue ("false") @QueryParam ("permanent") Boolean permanent) {
-    if ((educationTypeId == null) || (educationSubtypeId == null)) {
+    if (educationTypeId == null || educationSubtypeId == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -576,7 +576,7 @@ public class CommonRESTService extends AbstractRESTService {
     Double gpa = entity.getGpa();
     String qualification = entity.getQualification();
     
-    if (StringUtils.isBlank(name) || StringUtils.isBlank(description) || (passingGrade == null)) {
+    if (StringUtils.isBlank(name) || StringUtils.isBlank(description) || passingGrade == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -666,7 +666,7 @@ public class CommonRESTService extends AbstractRESTService {
     Double gpa = entity.getGpa();
     String qualification = entity.getQualification();
     
-    if (StringUtils.isBlank(name) || StringUtils.isBlank(description) || (passingGrade == null)) {
+    if (StringUtils.isBlank(name) || StringUtils.isBlank(description) || passingGrade == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/CourseRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/CourseRESTService.java
@@ -653,7 +653,7 @@ public class CourseRESTService extends AbstractRESTService {
     Date studyStartDate = student.getStudyStartDate();
     Date studyEndDate = student.getStudyEndDate();
     
-    if ((studyStartDate == null) && (studyEndDate == null)) {
+    if (studyStartDate == null && studyEndDate == null) {
       // It's a never ending study programme
       return true;
     }
@@ -682,7 +682,7 @@ public class CourseRESTService extends AbstractRESTService {
       return Response.status(Status.NOT_FOUND).build();
     }
     
-    if ((courseStudent.getArchived())||(courseStudent.getStudent().getArchived())||(courseStudent.getCourse().getArchived())) {
+    if (courseStudent.getArchived() || courseStudent.getStudent().getArchived() || courseStudent.getCourse().getArchived()) {
       return Response.status(Status.NOT_FOUND).build();
     }
     
@@ -1461,7 +1461,7 @@ public class CourseRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if (StringUtils.isBlank(entity.getKey())||StringUtils.isBlank(entity.getName())||(entity.getType() == null)||(entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getKey())||StringUtils.isBlank(entity.getName())|| entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -1517,7 +1517,7 @@ public class CourseRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if (StringUtils.isBlank(entity.getName())||(entity.getType() == null)||(entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getName())|| entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/CourseRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/CourseRESTService.java
@@ -600,7 +600,7 @@ public class CourseRESTService extends AbstractRESTService {
       return Response.status(Status.NOT_FOUND).build();
     }
 
-    List<CourseParticipationType> courseParticipationTypes = new ArrayList<CourseParticipationType>();
+    List<CourseParticipationType> courseParticipationTypes = new ArrayList<>();
     if (StringUtils.isNotEmpty(participationTypes)) {
       String[] typeArray = participationTypes.split(",");
       for (int i = 0; i < typeArray.length; i++) {

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/ModuleRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/ModuleRESTService.java
@@ -388,7 +388,7 @@ public class ModuleRESTService extends AbstractRESTService{
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if (StringUtils.isBlank(entity.getKey())||StringUtils.isBlank(entity.getName())||(entity.getType() == null)||(entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getKey())||StringUtils.isBlank(entity.getName())|| entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -444,7 +444,7 @@ public class ModuleRESTService extends AbstractRESTService{
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if (StringUtils.isBlank(entity.getName())||(entity.getType() == null)||(entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getName())|| entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/ObjectFactory.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/ObjectFactory.java
@@ -101,7 +101,7 @@ public class ObjectFactory {
   
   @PostConstruct
   public void init() {
-    mappers = new HashMap<Class<?>, ObjectFactory.Mapper<Object>>();
+    mappers = new HashMap<>();
     
     addMappers(
         new Mapper<fi.otavanopisto.pyramus.domainmodel.base.AcademicTerm>() {
@@ -162,7 +162,7 @@ public class ObjectFactory {
               subjectId = courseSubject.getId();
             }
             
-            List<String> tags = new ArrayList<String>();
+            List<String> tags = new ArrayList<>();
             Set<Tag> courseTags = entity.getTags();
             if (courseTags != null) {
               for (Tag courseTag : courseTags) {

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/PersonRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/PersonRESTService.java
@@ -90,7 +90,7 @@ public class PersonRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if ((entity.getSex() == null) || (entity.getSecureInfo() == null)) {
+    if (entity.getSex() == null || entity.getSecureInfo() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -151,7 +151,7 @@ public class PersonRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if ((entity.getSex() == null) || (entity.getSecureInfo() == null)) {
+    if (entity.getSex() == null || entity.getSecureInfo() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/ProjectRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/ProjectRESTService.java
@@ -171,7 +171,7 @@ public class ProjectRESTService extends AbstractRESTService {
       return Response.status(Status.NOT_FOUND).build();
     }
     
-    if ((moduleEntity.getModuleId() == null) || (moduleEntity.getOptionality() == null)) {
+    if (moduleEntity.getModuleId() == null || moduleEntity.getOptionality() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/SchoolRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/SchoolRESTService.java
@@ -229,7 +229,7 @@ public class SchoolRESTService extends AbstractRESTService {
     Boolean defaultAddress = email.getDefaultAddress();
     String address = email.getAddress();
     
-    if ((contactTypeId == null) || (defaultAddress == null) || StringUtils.isBlank(address)) {
+    if (contactTypeId == null || defaultAddress == null || StringUtils.isBlank(address)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -339,7 +339,7 @@ public class SchoolRESTService extends AbstractRESTService {
     String country = address.getCountry();
     String city = address.getCity();
     
-    if ((contactTypeId == null) || (defaultAddress == null)) {
+    if (contactTypeId == null || defaultAddress == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -445,7 +445,7 @@ public class SchoolRESTService extends AbstractRESTService {
     Boolean defaultNumber = phoneNumber.getDefaultNumber();
     String number = phoneNumber.getNumber();
     
-    if ((contactTypeId == null) || (defaultNumber == null) || StringUtils.isBlank(number)) {
+    if (contactTypeId == null || defaultNumber == null || StringUtils.isBlank(number)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -550,7 +550,7 @@ public class SchoolRESTService extends AbstractRESTService {
     Long contactURLTypeId = contactURL.getContactURLTypeId();
     String url = contactURL.getUrl();
     
-    if ((contactURLTypeId == null) || StringUtils.isBlank(url)) {
+    if (contactURLTypeId == null || StringUtils.isBlank(url)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -711,7 +711,7 @@ public class SchoolRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if (StringUtils.isBlank(entity.getKey())||StringUtils.isBlank(entity.getName())||(entity.getType() == null)||(entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getKey())||StringUtils.isBlank(entity.getName())|| entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
@@ -767,7 +767,7 @@ public class SchoolRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
     
-    if (StringUtils.isBlank(entity.getName())||(entity.getType() == null)||(entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getName())|| entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
     

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/StaffRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/StaffRESTService.java
@@ -65,7 +65,7 @@ public class StaffRESTService extends AbstractRESTService {
     List<StaffMember> staffMembers = null;
     
     if (StringUtils.isNotBlank(email)) {
-      staffMembers = new ArrayList<StaffMember>();
+      staffMembers = new ArrayList<>();
       StaffMember staffMember = userController.findStaffMemberByEmail(email);
       if (staffMember != null) {
         staffMembers.add(staffMember);

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/StaffRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/StaffRESTService.java
@@ -84,7 +84,7 @@ public class StaffRESTService extends AbstractRESTService {
   public Response findStaffMemberById(@PathParam("ID") Long id, @Context Request request) {
     StaffMember staffMember = userController.findStaffMemberById(id);
     
-    if ((staffMember == null) || (staffMember.getArchived())) {
+    if (staffMember == null || staffMember.getArchived()) {
       return Response.status(Status.NOT_FOUND).build();
     }
     
@@ -179,7 +179,7 @@ public class StaffRESTService extends AbstractRESTService {
     String country = address.getCountry();
     String city = address.getCity();
 
-    if ((contactTypeId == null) || (defaultAddress == null)) {
+    if (contactTypeId == null || defaultAddress == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -303,7 +303,7 @@ public class StaffRESTService extends AbstractRESTService {
     Boolean defaultNumber = phoneNumber.getDefaultNumber();
     String number = phoneNumber.getNumber();
 
-    if ((contactTypeId == null) || (defaultNumber == null) || StringUtils.isBlank(number)) {
+    if (contactTypeId == null || defaultNumber == null || StringUtils.isBlank(number)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/StudentRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/StudentRESTService.java
@@ -817,7 +817,7 @@ public class StudentRESTService extends AbstractRESTService {
     String code = entity.getCode();
     Long categoryId = entity.getCategoryId();
 
-    if (StringUtils.isBlank(name) || StringUtils.isBlank(code) || (categoryId == null)) {
+    if (StringUtils.isBlank(name) || StringUtils.isBlank(code) || categoryId == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -889,7 +889,7 @@ public class StudentRESTService extends AbstractRESTService {
     String code = entity.getCode();
     Long categoryId = entity.getCategoryId();
 
-    if (StringUtils.isBlank(name) || StringUtils.isBlank(code) || (categoryId == null)) {
+    if (StringUtils.isBlank(name) || StringUtils.isBlank(code) || categoryId == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -1353,7 +1353,7 @@ public class StudentRESTService extends AbstractRESTService {
     String lastName = entity.getLastName();
     Boolean lodging = entity.getLodging();
 
-    if ((personId == null) || (studyProgrammeId == null) || (lodging == null)) {
+    if (personId == null || studyProgrammeId == null || lodging == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -1482,7 +1482,7 @@ public class StudentRESTService extends AbstractRESTService {
     String lastName = entity.getLastName();
     Boolean lodging = entity.getLodging();
 
-    if ((personId == null) || (studyProgrammeId == null) || (lodging == null)) {
+    if (personId == null || studyProgrammeId == null || lodging == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -2179,7 +2179,7 @@ public class StudentRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
-    if (StringUtils.isBlank(entity.getKey()) || StringUtils.isBlank(entity.getName()) || (entity.getType() == null) || (entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getKey()) || StringUtils.isBlank(entity.getName()) || entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -2235,7 +2235,7 @@ public class StudentRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
-    if (StringUtils.isBlank(entity.getName()) || (entity.getType() == null) || (entity.getUserEditable() == null)) {
+    if (StringUtils.isBlank(entity.getName()) || entity.getType() == null || entity.getUserEditable() == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -2331,7 +2331,7 @@ public class StudentRESTService extends AbstractRESTService {
     Boolean defaultAddress = email.getDefaultAddress();
     String address = email.getAddress();
 
-    if ((contactTypeId == null) || (defaultAddress == null) || StringUtils.isBlank(address)) {
+    if (contactTypeId == null || defaultAddress == null || StringUtils.isBlank(address)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -2482,7 +2482,7 @@ public class StudentRESTService extends AbstractRESTService {
     String country = address.getCountry();
     String city = address.getCity();
 
-    if ((contactTypeId == null) || (defaultAddress == null)) {
+    if (contactTypeId == null || defaultAddress == null) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -2604,7 +2604,7 @@ public class StudentRESTService extends AbstractRESTService {
     Boolean defaultNumber = phoneNumber.getDefaultNumber();
     String number = phoneNumber.getNumber();
 
-    if ((contactTypeId == null) || (defaultNumber == null) || StringUtils.isBlank(number)) {
+    if (contactTypeId == null || defaultNumber == null || StringUtils.isBlank(number)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -2709,7 +2709,7 @@ public class StudentRESTService extends AbstractRESTService {
     Long contactURLTypeId = contactURL.getContactURLTypeId();
     String url = contactURL.getUrl();
 
-    if ((contactURLTypeId == null) || StringUtils.isBlank(url)) {
+    if (contactURLTypeId == null || StringUtils.isBlank(url)) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 

--- a/smvcj/src/main/java/fi/internetix/smvc/controllers/RequestContext.java
+++ b/smvcj/src/main/java/fi/internetix/smvc/controllers/RequestContext.java
@@ -53,7 +53,7 @@ public abstract class RequestContext {
     this.servletContext = servletContext;
     
     if (ServletFileUpload.isMultipartContent(servletRequest)) {
-      multipartFields = new HashMap<String, FileItem>();
+      multipartFields = new HashMap<>();
       
       ServletFileUpload servletFileUpload = new ServletFileUpload(new DiskFileItemFactory());
       servletFileUpload.setHeaderEncoding("UTF-8");
@@ -320,6 +320,6 @@ public abstract class RequestContext {
   /**
    * The messages of this context.
    */
-  private List<SmvcMessage> messages = new ArrayList<SmvcMessage>();
+  private List<SmvcMessage> messages = new ArrayList<>();
 
 }

--- a/smvcj/src/main/java/fi/internetix/smvc/controllers/RequestControllerMapper.java
+++ b/smvcj/src/main/java/fi/internetix/smvc/controllers/RequestControllerMapper.java
@@ -39,6 +39,6 @@ public class RequestControllerMapper {
   /**
    * Hashmap for page request controller names and their instances.
    */
-  private static Map<String, RequestController> requestControllers = new HashMap<String, RequestController>();
+  private static Map<String, RequestController> requestControllers = new HashMap<>();
 
 }

--- a/smvcj/src/main/java/fi/internetix/smvc/dispatcher/Servlet.java
+++ b/smvcj/src/main/java/fi/internetix/smvc/dispatcher/Servlet.java
@@ -314,7 +314,7 @@ public class Servlet extends HttpServlet {
   private PlatformErrorListener platformErrorListener;
 
   private boolean sessionSynchronization = false;
-  private Map<String, Object> syncObjects =  new HashMap<String, Object>();
+  private Map<String, Object> syncObjects = new HashMap<>();
 
   private static final long serialVersionUID = 1L;
   

--- a/smvcj/src/main/java/fi/internetix/smvc/i18n/Messages.java
+++ b/smvcj/src/main/java/fi/internetix/smvc/i18n/Messages.java
@@ -57,7 +57,7 @@ public class Messages {
     return bundles.get(locale);
   }
   
-  private Map<Locale, ResourceBundle> bundles = new HashMap<Locale, ResourceBundle>();
+  private Map<Locale, ResourceBundle> bundles = new HashMap<>();
   
   static {
     instance = new Messages();

--- a/testauth-plugin/src/main/java/fi/otavanopisto/pyramus/plugin/testauth/TestAuthPluginDescriptor.java
+++ b/testauth-plugin/src/main/java/fi/otavanopisto/pyramus/plugin/testauth/TestAuthPluginDescriptor.java
@@ -28,7 +28,7 @@ public class TestAuthPluginDescriptor implements PluginDescriptor {
   }
 
   public Map<String, Class<?>> getAuthenticationProviders() {
-    Map<String, Class<?>> authenticationProviders = new HashMap<String, Class<?>>();
+    Map<String, Class<?>> authenticationProviders = new HashMap<>();
     authenticationProviders.put("TestAuth", TestAuthorizationStrategy.class);
     return authenticationProviders;
   }

--- a/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/PyramusService.java
+++ b/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/PyramusService.java
@@ -14,7 +14,7 @@ public class PyramusService {
   	SystemDAO systemDAO = DAOFactory.getInstance().getSystemDAO(); 
   	  
   	Set<ConstraintViolation<Object>> constraintViolations = systemDAO.validateEntity(entity);
-  	if (constraintViolations.size() != 0) {
+  	if (!constraintViolations.isEmpty()) {
   	  String message = "";
   	  for (ConstraintViolation<Object> constraintViolation : constraintViolations) {
   	    message += constraintViolation.getMessage() + '\n';

--- a/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/entities/EntityFactoryVault.java
+++ b/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/entities/EntityFactoryVault.java
@@ -285,8 +285,8 @@ public class EntityFactoryVault {
     return pojoEntityClassMap.get(pojoClass);
   }
   
-  private static Map<Class<?>, EntityFactory<?>> factories = new HashMap<Class<?>, EntityFactory<?>>();
-  private static Map<Class<?>, Class<?>> pojoEntityClassMap = new HashMap<Class<?>, Class<?>>();
+  private static Map<Class<?>, EntityFactory<?>> factories = new HashMap<>();
+  private static Map<Class<?>, Class<?>> pojoEntityClassMap = new HashMap<>();
 
   static {
     /* Base */ 

--- a/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/entities/users/UserEntityFactory.java
+++ b/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/entities/users/UserEntityFactory.java
@@ -14,7 +14,7 @@ public class UserEntityFactory implements EntityFactory<UserEntity> {
   public UserEntity buildFromDomainObject(Object domainObject) {
     StaffMember user = (StaffMember) domainObject;
     
-    Set<String> emails = new HashSet<String>();
+    Set<String> emails = new HashSet<>();
     for (Email email : user.getContactInfo().getEmails())
       emails.add(email.getAddress());
     

--- a/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/utils/IpFilter.java
+++ b/webservices-plugin/src/main/java/fi/otavanopisto/pyramus/services/utils/IpFilter.java
@@ -39,5 +39,5 @@ public class IpFilter implements Filter {
   public void destroy() {
   }
   
-  private Set<String> allowedIPs = new HashSet<String>();
+  private Set<String> allowedIPs = new HashSet<>();
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.