### PR TITLE
"entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/PageHookVault.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/PageHookVault.java
@@ -51,8 +51,8 @@ public class PageHookVault {
     for (PluginDescriptor plugin : plugins) {
       if (plugin.getPageHookControllers() != null) {
         Map<String, Class<?>> pageHooks = plugin.getPageHookControllers();
-        for (String pageHookName : pageHooks.keySet()) {
-          getInstance().registerPageHook(pageHookName, pageHooks.get(pageHookName));
+        for (Map.Entry<String, Class<?>> entry : pageHooks.entrySet()) {
+          getInstance().registerPageHook(entry.getKey(), entry.getValue());
         }
       }
     }

--- a/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
+++ b/plugin-core/src/main/java/fi/otavanopisto/pyramus/plugin/auth/AuthenticationProviderVault.java
@@ -135,8 +135,8 @@ public class AuthenticationProviderVault {
     for (PluginDescriptor plugin : plugins) {
       if (plugin.getAuthenticationProviders() != null) {
         Map<String, Class<?>> authenticationProviders = plugin.getAuthenticationProviders();
-        for (String authenticationProviderName : authenticationProviders.keySet()) {
-          registerAuthenticationProviderClass(authenticationProviderName, authenticationProviders.get(authenticationProviderName));
+        for (Map.Entry<String, Class<?>> entry : authenticationProviders.entrySet()) {
+          registerAuthenticationProviderClass(entry.getKey(), entry.getValue());
         }
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/PyramusServletContextListener.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/PyramusServletContextListener.java
@@ -221,46 +221,46 @@ public class PyramusServletContextListener implements ServletContextListener {
       for (PluginDescriptor plugin : plugins) {
         Map<String, Class<?>> pageRequestControllers = plugin.getPageRequestControllers();
         if (pageRequestControllers != null) {
-          for (String key : pageRequestControllers.keySet()) {
-            String className = pageRequestControllers.get(key).getName();
+          for (Map.Entry<String, Class<?>> entry : pageRequestControllers.entrySet()) {
+            String className = entry.getValue().getName();
             Class<? extends RequestController> pageController = (Class<? extends RequestController>) Class.forName(className, false, pluginManager.getPluginsClassLoader());
-            RequestController oldController = RequestControllerMapper.getRequestController(key + ".page");
+            RequestController oldController = RequestControllerMapper.getRequestController(entry.getKey() + ".page");
             if (oldController != null) {
               // Save masked controllers for extending existing functionality by calling
               // the masked controller's .process()
-              RequestControllerMapper.mapController(key, ".page.masked", oldController);
+              RequestControllerMapper.mapController(entry.getKey(), ".page.masked", oldController);
             }
-            RequestControllerMapper.mapController(key, ".page", pageController.newInstance());
+            RequestControllerMapper.mapController(entry.getKey(), ".page", pageController.newInstance());
           }
         }
         
         Map<String, Class<?>> jsonRequestControllers = plugin.getJSONRequestControllers();
         if (jsonRequestControllers != null) {
-          for (String key : jsonRequestControllers.keySet()) {
-            String className = jsonRequestControllers.get(key).getName();
+          for (Map.Entry<String, Class<?>> entry : jsonRequestControllers.entrySet()) {
+            String className = entry.getValue().getName();
             Class<? extends RequestController> pageController = (Class<? extends RequestController>) Class.forName(className, false, pluginManager.getPluginsClassLoader());
-            RequestController oldController = RequestControllerMapper.getRequestController(key + ".json");
+            RequestController oldController = RequestControllerMapper.getRequestController(entry.getKey() + ".json");
             if (oldController != null) {
               // Save masked controllers for extending existing functionality by calling
               // the masked controller's .process()
-              RequestControllerMapper.mapController(key, ".json.masked", oldController);
+              RequestControllerMapper.mapController(entry.getKey(), ".json.masked", oldController);
             }
-            RequestControllerMapper.mapController(key, ".json", pageController.newInstance());
+            RequestControllerMapper.mapController(entry.getKey(), ".json", pageController.newInstance());
           }
         }
         
         Map<String, Class<?>> binaryRequestControllers = plugin.getBinaryRequestControllers();
         if (binaryRequestControllers != null) {
-          for (String key : binaryRequestControllers.keySet()) {
-            String className = binaryRequestControllers.get(key).getName();
+          for (Map.Entry<String, Class<?>> entry : binaryRequestControllers.entrySet()) {
+            String className = entry.getValue().getName();
             Class<? extends RequestController> pageController = (Class<? extends RequestController>) Class.forName(className, false, pluginManager.getPluginsClassLoader());
-            RequestController oldController = RequestControllerMapper.getRequestController(key + ".binary");
+            RequestController oldController = RequestControllerMapper.getRequestController(entry.getKey() + ".binary");
             if (oldController != null) {
               // Save masked controllers for extending existing functionality by calling
               // the masked controller's .process()
-              RequestControllerMapper.mapController(key, ".binary.masked", oldController);
+              RequestControllerMapper.mapController(entry.getKey(), ".binary.masked", oldController);
             }
-            RequestControllerMapper.mapController(key, ".binary", pageController.newInstance());
+            RequestControllerMapper.mapController(entry.getKey(), ".binary", pageController.newInstance());
           }
         }
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/binary/reports/DownloadReportBinaryRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/binary/reports/DownloadReportBinaryRequestController.java
@@ -91,13 +91,13 @@ public class DownloadReportBinaryRequestController extends BinaryRequestControll
       .append(outputFormat.name());
     
     Map<String, String[]> parameterMap = binaryRequestContext.getRequest().getParameterMap();
-    for (String parameterName : parameterMap.keySet()) {
-      if (!reservedParameters.contains(parameterName)) {
-        String[] values = parameterMap.get(parameterName);
+    for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+      if (!reservedParameters.contains(entry.getKey())) {
+        String[] values = entry.getValue();
         for (String value : values) {
           // TODO ISO-8859-1 should be UTF-8, once Birt's parameter dialog form has its accept-charset="UTF-8" set 
           try {
-            urlBuilder.append('&').append(parameterName).append('=').append(URLEncoder.encode(value, "ISO-8859-1"));
+            urlBuilder.append('&').append(entry.getKey()).append('=').append(URLEncoder.encode(value, "ISO-8859-1"));
           }
           catch (UnsupportedEncodingException e) {
             throw new SmvcRuntimeException(e);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/changelog/ChangeLogJPAEventsListener.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/changelog/ChangeLogJPAEventsListener.java
@@ -201,8 +201,8 @@ public class ChangeLogJPAEventsListener implements MessageListener {
     // And finally we can iterate values map values into the database
     if (!values.isEmpty()) {
       ChangeLogEntry entry = logEntryDAO.create(changeLogEntryEntity, ChangeLogEntryType.Update, String.valueOf(id), time, loggedUser);
-      for (ChangeLogEntryEntityProperty property : values.keySet()) {
-        logEntryPropertyDAO.create(entry, property, values.get(property));
+      for (Map.Entry<ChangeLogEntryEntityProperty, String> changeLogEntry : values.entrySet()) {
+        logEntryPropertyDAO.create(entry, changeLogEntry.getKey(), changeLogEntry.getValue());
       }
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/CreateCourseJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/CreateCourseJSONRequestController.java
@@ -374,16 +374,16 @@ public class CreateCourseJSONRequestController extends JSONRequestController {
         }
       }
     }
-    for (Long educationTypeId : chosenEducationTypes.keySet()) {
-      EducationType educationType = educationTypeDAO.findById(educationTypeId);
+    for (Map.Entry<Long, Vector<Long>> entry : chosenEducationTypes.entrySet()) {
+      EducationType educationType = educationTypeDAO.findById(entry.getKey());
       CourseEducationType courseEducationType;
       if (!course.contains(educationType)) {
         courseEducationType = courseEducationTypeDAO.create(course, educationType);
       }
       else {
-        courseEducationType = course.getCourseEducationTypeByEducationTypeId(educationTypeId);
+        courseEducationType = course.getCourseEducationTypeByEducationTypeId(entry.getKey());
       }
-      for (Long educationSubtypeId : chosenEducationTypes.get(educationTypeId)) {
+      for (Long educationSubtypeId : entry.getValue()) {
         EducationSubtype educationSubtype = educationSubtypeDAO.findById(educationSubtypeId);
         if (!courseEducationType.contains(educationSubtype)) {
           courseEducationSubtypeDAO.create(courseEducationType, educationSubtype);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/EditCourseJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/courses/EditCourseJSONRequestController.java
@@ -347,16 +347,16 @@ public class EditCourseJSONRequestController extends JSONRequestController {
 
     // Add education types and subtypes
 
-    for (Long educationTypeId : chosenEducationTypes.keySet()) {
-      EducationType educationType = educationTypeDAO.findById(educationTypeId);
+    for (Map.Entry<Long, Vector<Long>> entry : chosenEducationTypes.entrySet()) {
+      EducationType educationType = educationTypeDAO.findById(entry.getKey());
       CourseEducationType courseEducationType;
       if (!course.contains(educationType)) {
         courseEducationType = courseEducationTypeDAO.create(course, educationType);
       }
       else {
-        courseEducationType = course.getCourseEducationTypeByEducationTypeId(educationTypeId);
+        courseEducationType = course.getCourseEducationTypeByEducationTypeId(entry.getKey());
       }
-      for (Long educationSubtypeId : chosenEducationTypes.get(educationTypeId)) {
+      for (Long educationSubtypeId : entry.getValue()) {
         EducationSubtype educationSubtype = educationSubtypeDAO.findById(educationSubtypeId);
         if (!courseEducationType.contains(educationSubtype)) {
           courseEducationSubtypeDAO.create(courseEducationType, educationSubtype);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/CreateModuleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/CreateModuleJSONRequestController.java
@@ -144,16 +144,16 @@ public class CreateModuleJSONRequestController extends JSONRequestController {
 
     // Add education types and subtypes
 
-    for (Long educationTypeId : chosenEducationTypes.keySet()) {
-      EducationType educationType = educationTypeDAO.findById(educationTypeId);
+    for (Map.Entry<Long, Vector<Long>> entry : chosenEducationTypes.entrySet()) {
+      EducationType educationType = educationTypeDAO.findById(entry.getKey());
       CourseEducationType courseEducationType;
       if (!module.contains(educationType)) {
         courseEducationType = courseEducationTypeDAO.create(module, educationType);
       }
       else {
-        courseEducationType = module.getCourseEducationTypeByEducationTypeId(educationTypeId);
+        courseEducationType = module.getCourseEducationTypeByEducationTypeId(entry.getKey());
       }
-      for (Long educationSubtypeId : chosenEducationTypes.get(educationTypeId)) {
+      for (Long educationSubtypeId : entry.getValue()) {
         EducationSubtype educationSubtype = educationSubtypeDAO.findById(educationSubtypeId);
 
         if (!courseEducationType.contains(educationSubtype)) {

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/EditModuleJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/modules/EditModuleJSONRequestController.java
@@ -142,16 +142,16 @@ public class EditModuleJSONRequestController extends JSONRequestController {
 
     // Add education types and subtypes
 
-    for (Long educationTypeId : chosenEducationTypes.keySet()) {
-      EducationType educationType = educationTypeDAO.findById(educationTypeId);
+    for (Map.Entry<Long, Vector<Long>> entry : chosenEducationTypes.entrySet()) {
+      EducationType educationType = educationTypeDAO.findById(entry.getKey());
       CourseEducationType courseEducationType;
       if (!module.contains(educationType)) {
         courseEducationType = courseEducationTypeDAO.create(module, educationType);
       }
       else {
-        courseEducationType = module.getCourseEducationTypeByEducationTypeId(educationTypeId);
+        courseEducationType = module.getCourseEducationTypeByEducationTypeId(entry.getKey());
       }
-      for (Long educationSubtypeId : chosenEducationTypes.get(educationTypeId)) {
+      for (Long educationSubtypeId : entry.getValue()) {
         EducationSubtype educationSubtype = educationSubtypeDAO.findById(educationSubtypeId);
         if (!courseEducationType.contains(educationSubtype)) {
           courseEducationSubtypeDAO.create(courseEducationType, educationSubtype);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/ViewReportContentsViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/reports/ViewReportContentsViewController.java
@@ -73,13 +73,13 @@ public class ViewReportContentsViewController extends PyramusViewController impl
     // TODO: Report locale is wrong.
     
     Map<String, String[]> parameterMap = pageRequestContext.getRequest().getParameterMap();
-    for (String parameterName : parameterMap.keySet()) {
-      if (!reservedParameters.contains(parameterName)) {
-        String[] values = parameterMap.get(parameterName);
+    for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+      if (!reservedParameters.contains(entry.getKey())) {
+        String[] values = entry.getValue();
         for (String value : values) {
           // TODO ISO-8859-1 should be UTF-8, once Birt's parameter dialog form has its accept-charset="UTF-8" set 
           try {
-            urlBuilder.append('&').append(parameterName).append('=').append(URLEncoder.encode(value, "ISO-8859-1"));
+            urlBuilder.append('&').append(entry.getKey()).append('=').append(URLEncoder.encode(value, "ISO-8859-1"));
           }
           catch (UnsupportedEncodingException e) {
             throw new SmvcRuntimeException(e);

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/studentfiles/UploadReportDialogViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/studentfiles/UploadReportDialogViewController.java
@@ -44,13 +44,13 @@ public class UploadReportDialogViewController extends PyramusViewController {
     StringBuffer reportParameters = new StringBuffer();
     
     Map<String, String[]> parameterMap = pageRequestContext.getRequest().getParameterMap();
-    for (String parameterName : parameterMap.keySet()) {
-      if (!reservedParameters.contains(parameterName)) {
-        String[] values = parameterMap.get(parameterName);
+    for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+      if (!reservedParameters.contains(entry.getKey())) {
+        String[] values = entry.getValue();
         for (String value : values) {
           // TODO ISO-8859-1 should be UTF-8, once Birt's parameter dialog form has its accept-charset="UTF-8" set 
           try {
-            reportParameters.append('&').append(parameterName).append('=').append(URLEncoder.encode(value, "ISO-8859-1"));
+            reportParameters.append('&').append(entry.getKey()).append('=').append(URLEncoder.encode(value, "ISO-8859-1"));
           }
           catch (UnsupportedEncodingException e) {
             throw new SmvcRuntimeException(e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.