### PR TITLE
Bug 444 duplications during wizard time

### DIFF
--- a/pyramus/src/main/webapp/WEB-INF/tags/setupwizard-template.tag
+++ b/pyramus/src/main/webapp/WEB-INF/tags/setupwizard-template.tag
@@ -16,6 +16,7 @@
 <jsp:include page="/templates/generic/table_support.jsp"></jsp:include>
 <jsp:include page="/templates/generic/jsonrequest_support.jsp"></jsp:include>
 <jsp:include page="/templates/generic/jsonform_support.jsp"></jsp:include>
+<jsp:include page="/templates/generic/pageform_support.jsp"></jsp:include>
 <jsp:include page="/templates/generic/draftapi_support.jsp"></jsp:include>
 <jsp:include page="/templates/generic/validation_support.jsp"></jsp:include>
 <jsp:include page="/templates/generic/locale_support.jsp"></jsp:include>

--- a/pyramus/src/main/webapp/templates/generic/pageform_support.jsp
+++ b/pyramus/src/main/webapp/templates/generic/pageform_support.jsp
@@ -1,0 +1,33 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<jsp:include page="/templates/generic/glasspane_support.jsp"></jsp:include>
+
+<c:choose>
+  <c:when test="${pageformSupportIncluded != true}">
+    <script type="text/javascript">
+      function initializePageForms() {
+        var forms = $$("form[ix:pageform='true']");
+        
+        for (var i = 0; i < forms.length; i++) {
+          var form = forms[i];
+          
+          Event.observe(form, "submit", function (event) {
+            var formElement = Event.element(event);
+            formElement._globalGlassPane = new IxGlassPane(document.body, { });
+            formElement._globalGlassPane.show();
+            
+            return true;
+          });
+        }
+      }
+      
+      Event.observe(window, "load", function (event) {
+    	  initializePageForms();
+      });
+    </script>
+    
+    <c:set scope="request" var="pageformSupportIncluded" value="true"/>
+  </c:when>
+</c:choose>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/academicterms.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/academicterms.jsp
@@ -10,7 +10,7 @@
   <jsp:body>
     
 
-        <form action="" method="post" >
+        <form action="" method="post" ix:pageform="true">
           <div id="manageAcademicTermsListTerms" class="tabContentixTableFormattedData">
             <div class="genericTableAddRowContainer">
               <span class="genericTableAddRowLinkContainer" onclick="addTermsTableRow();"><fmt:message key="system.setupwizard.academicterms.addTermLink"/></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/adminpassword.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/adminpassword.jsp
@@ -7,7 +7,7 @@
 	<jsp:attribute name="script">
 </jsp:attribute>
 	<jsp:body>
-<form method="post" action="">
+<form method="post" action="" ix:pageform="true">
 		<div class="tabContent">
             <div class="genericFormSection">  
               <jsp:include

--- a/pyramus/src/main/webapp/templates/system/setupwizard/contacttypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/contacttypes.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addContactTypesTableRow();"><fmt:message key="system.setupwizard.contactTypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/courseparticipationtypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/courseparticipationtypes.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="courseParticipationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addCourseParticipationTypesTableRow();"><fmt:message key="system.setupwizard.courseparticipationtypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/coursestates.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/coursestates.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addCourseStatesTableRow();"><fmt:message key="system.setupwizard.coursestates.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/coursetypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/coursetypes.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addCourseTypesTableRow();"><fmt:message key="system.setupwizard.courseTypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/educationsubtypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/educationsubtypes.jsp
@@ -8,7 +8,7 @@ pageEncoding="UTF-8"%>
 <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/educationsubtypes.js"></script>
 </jsp:attribute>
 <jsp:body>
-<form method="post">
+<form method="post" ix:pageform="true">
     <div id="educationSubtypes" class="tabContent">
         <div class="genericTableAddRowContainer">
             <span class="genericTableAddRowLinkContainer" onclick="addEducationSubtypesTableRow();"><fmt:message key="system.setupwizard.educationsubtypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/educationtypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/educationtypes.jsp
@@ -8,7 +8,7 @@ pageEncoding="UTF-8"%>
 <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/educationtypes.js"></script>
 </jsp:attribute>
 <jsp:body>
-<form method="post" action="">
+<form method="post" action="" ix:pageform="true">
     <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
             <span class="genericTableAddRowLinkContainer" onclick="addEducationTypesTableRow();"><fmt:message key="system.setupwizard.educationtypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/examinationtypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/examinationtypes.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addExaminationTypesTableRow();"><fmt:message key="system.setupwizard.examinationtypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/index.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/index.jsp
@@ -8,7 +8,7 @@
     <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/index.js"></script>
   </jsp:attribute>
   <jsp:body>
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div class="genericFormSubmitSectionOffTab">
         <input type="submit" class="formvalid" name="next" value="<fmt:message key="system.setupwizard.next"/>">
       </div>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/languages.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/languages.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="languages" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addLanguagesTableRow();"><fmt:message key="system.setupwizard.languages.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/municipalities.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/municipalities.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="municipalities" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addMunicipalitiesTableRow();"><fmt:message key="system.setupwizard.municipalities.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/nationalities.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/nationalities.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addNationalitiesTableRow();"><fmt:message key="system.setupwizard.nationalities.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/schoolfields.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/schoolfields.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addSchoolFieldsTableRow();"><fmt:message key="system.setupwizard.schoolfields.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/schools.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/schools.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addSchoolsTableRow();"><fmt:message key="system.setupwizard.schools.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/studentactivitytypes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/studentactivitytypes.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addStudentActivityTypesTableRow();"><fmt:message key="system.setupwizard.studentactivitytypes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/studenteducationallevels.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/studenteducationallevels.jsp
@@ -9,7 +9,7 @@
   </jsp:attribute>
   <jsp:body>
   
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
       <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addStudentEducationalLevelsTableRow();"><fmt:message key="system.setupwizard.studenteducationallevels.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/studyendreasons.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/studyendreasons.jsp
@@ -8,7 +8,7 @@
     <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/studyendreasons.js"></script>
   </jsp:attribute>
   <jsp:body>
-        <form action="" method="post" >
+        <form action="" method="post" ix:pageform="true">
           
           <div id="manageStudyEndReasons" class="tabContentixTableFormattedData">
             <div class="genericTableAddRowContainer">

--- a/pyramus/src/main/webapp/templates/system/setupwizard/studyprogrammecategories.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/studyprogrammecategories.jsp
@@ -8,7 +8,7 @@ pageEncoding="UTF-8"%>
 <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/studyprogrammecategories.js"></script>
 </jsp:attribute>
 <jsp:body>
-<form method="post" action="">
+<form method="post" action="" ix:pageform="true">
             
           <div id="manageStudyProgrammeCategories" class="tabContentixTableFormattedData">
             <div class="genericTableAddRowContainer">

--- a/pyramus/src/main/webapp/templates/system/setupwizard/studyprogrammes.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/studyprogrammes.jsp
@@ -8,7 +8,7 @@ pageEncoding="UTF-8"%>
 <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/studyprogrammes.js"></script>
 </jsp:attribute>
 <jsp:body>
-<form method="post">
+<form method="post" ix:pageform="true">
     <div id="studyProgrammes" class="tabContent">
         <div class="genericTableAddRowContainer">
             <span class="genericTableAddRowLinkContainer" onclick="addStudyProgrammesTableRow();"><fmt:message key="system.setupwizard.studyprogrammes.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/subjects.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/subjects.jsp
@@ -8,7 +8,7 @@ pageEncoding="UTF-8"%>
 <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/subjects.js"></script>
 </jsp:attribute>
 <jsp:body>
-<form method="post" action="">
+<form method="post" action="" ix:pageform="true">
     <div id="subjects" class="tabContent">
         <div class="genericTableAddRowContainer">
             <span class="genericTableAddRowLinkContainer" onclick="addSubjectsTableRow();"><fmt:message key="system.setupwizard.subjects.addNew" /></span>

--- a/pyramus/src/main/webapp/templates/system/setupwizard/timeunits.jsp
+++ b/pyramus/src/main/webapp/templates/system/setupwizard/timeunits.jsp
@@ -7,7 +7,7 @@
     <script type="text/javascript" src="${pageContext.request.contextPath}/scripts/gui/system/setupwizard/timeunits.js"></script>
   </jsp:attribute>
   <jsp:body>
-    <form method="post" action="">
+    <form method="post" action="" ix:pageform="true">
 	  <div id="educationTypes" class="tabContent">
         <div class="genericTableAddRowContainer">
           <span class="genericTableAddRowLinkContainer" onclick="addTimeUnitsTableRow();"><fmt:message key="settings.timeUnits.addTimeUnitLink"/></span>


### PR DESCRIPTION
This solves the bug https://github.com/otavanopisto/pyramus/issues/444 however it was found that this problem happened both in chrome, and chromium, but this behaviour was not observed in firefox in any page submission form (that means) it actually affected all the wizard steps.

So the new tag ix:pageform based on ix:jsonform named like that because it uses a page handler (the same a json uses a json handler) uses the overlay to avoid forms to be resubmitted; the same way that the forms in app do; so it doesn't actually disable the form but it does the job as it's the same mechanism used in the other ajax based forms.

It's possible to just disable the form in general but this already does the job, if you prefer another mechanism I can change the PR functionality.