### PR TITLE
Fix some incorrect NaN checks.

### DIFF
--- a/pyramus/src/main/webapp/scripts/ixhoverpanel/ixhoverpanel.js
+++ b/pyramus/src/main/webapp/scripts/ixhoverpanel/ixhoverpanel.js
@@ -19,13 +19,13 @@ IxHoverPanel = Class.create(
       this._updateContent(options.content);
     } 
     
-    if ((options.width != undefined) && (options.width != NaN)) {
+    if ((options.width != undefined) && !isNaN(options.width)) {
       this.domNode.setStyle({
         width: options.width + 'px'
       });
     }
     
-    if ((options.height != undefined) && (options.height != NaN)) {
+    if ((options.height != undefined) && !isNaN(options.height)) {
       this.domNode.setStyle({
         height: options.height + 'px'
       });

--- a/pyramus/src/main/webapp/scripts/ixtable/ixtable.js
+++ b/pyramus/src/main/webapp/scripts/ixtable/ixtable.js
@@ -106,19 +106,19 @@ IxTable = Class.create({
         }
       }
       
-      if ((column.left != undefined) && (column.left != NaN)) {
+      if ((column.left != undefined) && !isNaN(column.left)) {
         headerCell.setStyle( {
           left : column.left + 'px'
         });
       };
 
-      if ((column.right != undefined) && (column.right != NaN)) {
+      if ((column.right != undefined) && !isNaN(column.right)) {
         headerCell.setStyle( {
           right : column.right + 'px'
         });
       };
       
-      if ((column.width != undefined) && (column.width != NaN)) {
+      if ((column.width != undefined) && !isNaN(column.width)) {
         headerCell.setStyle( {
           width : column.width + 'px'
         });
@@ -193,17 +193,17 @@ IxTable = Class.create({
         var cellStyles = {};
         var hasStyles = false;
 
-        if ((column.left != undefined) && (column.left != NaN)) {
+        if ((column.left != undefined) && !isNaN(column.left)) {
           cellStyles.left = column.left + 'px';
           hasStyles = true;
         }
         
-        if ((column.right != undefined) && (column.right != NaN)) {
+        if ((column.right != undefined) && !isNaN(column.right)) {
           cellStyles.right = column.right + 'px';
           hasStyles = true;
         }
         
-        if ((column.width != undefined) && (column.width != NaN)) {
+        if ((column.width != undefined) && !isNaN(column.width)) {
           cellStyles.width = column.width + 'px';
           hasStyles = true;
         }

--- a/reports/src/main/webapp/scripts/ixdatefield/ixbirtdatefield.js
+++ b/reports/src/main/webapp/scripts/ixdatefield/ixbirtdatefield.js
@@ -116,7 +116,7 @@ IxDateField = Class.create({
     var mm = new Number(dateStr.substring(5, 7));
     var dd = new Number(dateStr.substring(8, 10));
     
-    if ((yyyy != NaN) && (mm != NaN) && (dd != NaN)) {
+    if (!isNaN(yyyy) && !isNaN(mm) && !isNaN(dd)) {
       try {
         var date = new Date();
         
@@ -182,7 +182,7 @@ IxDateField = Class.create({
       var year = this.getYear();
       var month = this.getMonth();
       var day = this.getDay();
-      if (year == NaN || month == NaN || day == NaN) {
+      if (isNaN(year) || isNaN(month) || isNaN(day)) {
         this._timestampInput.value = '';
       }
       else {


### PR DESCRIPTION
I spotted these checks of numbers against `NaN` that don't seem to be correct. In JavaScript `NaN` is not equal to anything, not even itself. I've fixed these to use the built in `isNaN` function instead which should correctly check if they are `NaN`.

---

I found these issues through [lgtm.com](https://lgtm.com/projects/g/otavanopisto/pyramus/alerts/), a service that analyzes open-source code to look for potential problems. (Full disclosure: I work for the company that operates it.)