### PR TITLE
Fixed issues with advanced module/course search

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/modules/ModuleDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/modules/ModuleDAO.java
@@ -252,7 +252,7 @@ public class ModuleDAO extends PyramusEntityDAO<Module> {
         addTokenizedSearchCriteria(queryBuilder, "subject.id", subject.getId().toString(), true);
 
       if (hasCurriculum)
-        addTokenizedSearchCriteria(queryBuilder, "curriculum.id", curriculum.getId().toString(), true);
+        addTokenizedSearchCriteria(queryBuilder, "curriculums.id", curriculum.getId().toString(), true);
 
       if (hasEduType)
         addTokenizedSearchCriteria(queryBuilder, "courseEducationTypes.educationType.id", educationType.getId().toString(), true);

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
@@ -376,7 +376,7 @@ public abstract class CourseBase implements ArchivableEntity {
   
   @ManyToOne  
   @JoinColumn(name="subject")
-  @IndexedEmbedded
+  @IndexedEmbedded(includeEmbeddedObjectId = true)
   private Subject subject;
 
   @Column
@@ -389,7 +389,7 @@ public abstract class CourseBase implements ArchivableEntity {
   
   @OneToMany (cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn (name="courseBase")
-  @IndexedEmbedded
+  @IndexedEmbedded(includeEmbeddedObjectId = true)
   private List<CourseEducationType> courseEducationTypes = new Vector<>();
 
   @NotNull
@@ -410,6 +410,6 @@ public abstract class CourseBase implements ArchivableEntity {
   
   @ManyToMany (fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinTable (name = "__CourseBaseCurriculums", joinColumns = @JoinColumn(name = "courseBase"), inverseJoinColumns = @JoinColumn(name = "curriculum"))
-  @IndexedEmbedded 
+  @IndexedEmbedded(includeEmbeddedObjectId = true) 
   private Set<Curriculum> curriculums = new HashSet<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseEducationSubtype.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseEducationSubtype.java
@@ -99,7 +99,7 @@ public class CourseEducationSubtype {
 
   @ManyToOne
   @JoinColumn(name = "educationSubtype", updatable = false)
-  @IndexedEmbedded
+  @IndexedEmbedded(includeEmbeddedObjectId = true)
   private EducationSubtype educationSubtype;
 
   @Version

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseEducationType.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseEducationType.java
@@ -159,12 +159,12 @@ public class CourseEducationType {
 
   @ManyToOne
   @JoinColumn(name = "educationType", updatable = false)
-  @IndexedEmbedded
+  @IndexedEmbedded(includeEmbeddedObjectId = true)
   private EducationType educationType;
 
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "courseEducationType")
-  @IndexedEmbedded
+  @IndexedEmbedded(includeEmbeddedObjectId = true)
   private List<CourseEducationSubtype> courseEducationSubtypes = new Vector<>();
 
   @Version


### PR DESCRIPTION
Fixes #622 

* Searches were made to embedded id's which weren't indexed (broken at some point likely due to lucene update [embedded id's stopped being indexed by default])
* Curriculum search was referencing curriculum.id while the indexed field is curriculums.id (changed when multiple curriculum support was added).