### PR TITLE
Added handling for archived students

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiAikuistenPerusopetuksenStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiAikuistenPerusopetuksenStudentHandler.java
@@ -77,11 +77,16 @@ public class KoskiAikuistenPerusopetuksenStudentHandler extends KoskiStudentHand
     StudentSubjectSelections studentSubjects = loadStudentSubjectSelections(student, getDefaultSubjectSelections());
     String studyOid = userVariableDAO.findByUserAndKey(student, KOSKI_STUDYPERMISSION_ID);
 
+    // Skip student if it is archived and the studyoid is blank
+    if (Boolean.TRUE.equals(student.getArchived()) && StringUtils.isBlank(studyOid)) {
+      return null;
+    }
+    
     AikuistenPerusopetuksenOpiskeluoikeus opiskeluoikeus = new AikuistenPerusopetuksenOpiskeluoikeus();
     opiskeluoikeus.setLahdejarjestelmanId(getLahdeJarjestelmaID(student.getId()));
     opiskeluoikeus.setAlkamispaiva(student.getStudyStartDate());
     opiskeluoikeus.setPaattymispaiva(student.getStudyEndDate());
-    if (studyOid != null) {
+    if (StringUtils.isNotBlank(studyOid)) {
       opiskeluoikeus.setOid(studyOid);
     }
 
@@ -89,7 +94,8 @@ public class KoskiAikuistenPerusopetuksenStudentHandler extends KoskiStudentHand
     
     handleLinkedStudyOID(student, opiskeluoikeus);
     
-    OpiskeluoikeusJakso jakso = new OpiskeluoikeusJakso(student.getStudyStartDate(), OpiskeluoikeudenTila.lasna);
+    OpiskeluoikeudenTila jaksonTila = !Boolean.TRUE.equals(student.getArchived()) ? OpiskeluoikeudenTila.lasna : OpiskeluoikeudenTila.mitatoity;
+    OpiskeluoikeusJakso jakso = new OpiskeluoikeusJakso(student.getStudyStartDate(), jaksonTila);
     jakso.setOpintojenRahoitus(new KoodistoViite<>(student.getSchool() == null ? OpintojenRahoitus.K1 : OpintojenRahoitus.K6));
     opiskeluoikeus.getTila().addOpiskeluoikeusJakso(jakso);
 

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiEventListeners.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiEventListeners.java
@@ -26,6 +26,7 @@ import fi.otavanopisto.pyramus.domainmodel.koski.KoskiPersonLog;
 import fi.otavanopisto.pyramus.domainmodel.koski.KoskiPersonState;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
 import fi.otavanopisto.pyramus.events.CourseAssessmentEvent;
+import fi.otavanopisto.pyramus.events.StudentArchivedEvent;
 import fi.otavanopisto.pyramus.events.StudentUpdatedEvent;
 import fi.otavanopisto.pyramus.events.TransferCreditEvent;
 
@@ -70,6 +71,10 @@ public class KoskiEventListeners implements Serializable {
   }
 
   public void onStudentUpdated(@Observes StudentUpdatedEvent event) {
+    studentChanged(event.getStudentId());
+  }
+  
+  public void onStudentArchived(@Observes StudentArchivedEvent event) {
     studentChanged(event.getStudentId());
   }
 

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiLukioStudentHandler.java
@@ -88,18 +88,25 @@ public class KoskiLukioStudentHandler extends KoskiStudentHandler {
       return null;
     }
     
+    // Skip student if it is archived and the studyoid is blank
+    if (Boolean.TRUE.equals(student.getArchived()) && StringUtils.isBlank(studyOid)) {
+      return null;
+    }
+    
     LukionOpiskeluoikeus opiskeluoikeus = new LukionOpiskeluoikeus();
     opiskeluoikeus.setLahdejarjestelmanId(getLahdeJarjestelmaID(student.getId()));
     opiskeluoikeus.setAlkamispaiva(student.getStudyStartDate());
     opiskeluoikeus.setPaattymispaiva(student.getStudyEndDate());
-    if (studyOid != null)
+    if (StringUtils.isNotBlank(studyOid)) {
       opiskeluoikeus.setOid(studyOid);
+    }
 
     opiskeluoikeus.setLisatiedot(getLisatiedot(student));
 
     handleLinkedStudyOID(student, opiskeluoikeus);
     
-    OpiskeluoikeusJakso jakso = new OpiskeluoikeusJakso(student.getStudyStartDate(), OpiskeluoikeudenTila.lasna);
+    OpiskeluoikeudenTila jaksonTila = !Boolean.TRUE.equals(student.getArchived()) ? OpiskeluoikeudenTila.lasna : OpiskeluoikeudenTila.mitatoity;
+    OpiskeluoikeusJakso jakso = new OpiskeluoikeusJakso(student.getStudyStartDate(), jaksonTila);
     jakso.setOpintojenRahoitus(new KoodistoViite<>(student.getSchool() == null ? OpintojenRahoitus.K1 : OpintojenRahoitus.K6));
     opiskeluoikeus.getTila().addOpiskeluoikeusJakso(jakso);
 

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiSettings.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiSettings.java
@@ -205,6 +205,7 @@ public class KoskiSettings {
   
   public boolean isReportedStudent(Student student) {
     return 
+        Boolean.FALSE.equals(student.getArchived()) &&
         isEnabledStudyProgramme(student.getStudyProgramme()) &&
         !Boolean.valueOf(userVariableDAO.findByUserAndKey(student, KOSKI_SKIPPED_STUDENT));
   }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiSettings.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiSettings.java
@@ -205,7 +205,6 @@ public class KoskiSettings {
   
   public boolean isReportedStudent(Student student) {
     return 
-        Boolean.FALSE.equals(student.getArchived()) &&
         isEnabledStudyProgramme(student.getStudyProgramme()) &&
         !Boolean.valueOf(userVariableDAO.findByUserAndKey(student, KOSKI_SKIPPED_STUDENT));
   }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/koodisto/OpiskeluoikeudenTila.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/koodisto/OpiskeluoikeudenTila.java
@@ -5,14 +5,15 @@ import fi.otavanopisto.pyramus.koski.KoodistoEnum;
 @KoodistoEnum("koskiopiskeluoikeudentila")
 public enum OpiskeluoikeudenTila {
 
-  lasna,
   eronnut,
-  erotettu,
   katsotaaneronneeksi,
+  lasna,
+  loma,
+  mitatoity,
   peruutettu,
   valiaikaisestikeskeytynyt,
   valmistunut;
   
-  public static final OpiskeluoikeudenTila[] QUIT_STATES = { eronnut, erotettu, katsotaaneronneeksi, peruutettu };
+  public static final OpiskeluoikeudenTila[] QUIT_STATES = { eronnut, katsotaaneronneeksi, peruutettu };
   public static final OpiskeluoikeudenTila[] GRADUATED_STATES = { valmistunut };
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/KoskiAPAStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/KoskiAPAStudentHandler.java
@@ -67,11 +67,16 @@ public class KoskiAPAStudentHandler extends KoskiStudentHandler {
     StudentSubjectSelections studentSubjects = loadStudentSubjectSelections(student, getDefaultStudentSubjectSelections());
     String studyOid = userVariableDAO.findByUserAndKey(student, KOSKI_STUDYPERMISSION_ID);
 
+    // Skip student if it is archived and the studyoid is blank
+    if (Boolean.TRUE.equals(student.getArchived()) && StringUtils.isBlank(studyOid)) {
+      return null;
+    }
+    
     AikuistenPerusopetuksenOpiskeluoikeus opiskeluoikeus = new AikuistenPerusopetuksenOpiskeluoikeus();
     opiskeluoikeus.setLahdejarjestelmanId(getLahdeJarjestelmaID(student.getId()));
     opiskeluoikeus.setAlkamispaiva(student.getStudyStartDate());
     opiskeluoikeus.setPaattymispaiva(student.getStudyEndDate());
-    if (studyOid != null) {
+    if (StringUtils.isNotBlank(studyOid)) {
       opiskeluoikeus.setOid(studyOid);
     }
     
@@ -79,7 +84,8 @@ public class KoskiAPAStudentHandler extends KoskiStudentHandler {
     
     handleLinkedStudyOID(student, opiskeluoikeus);
     
-    OpiskeluoikeusJakso jakso = new OpiskeluoikeusJakso(student.getStudyStartDate(), OpiskeluoikeudenTila.lasna);
+    OpiskeluoikeudenTila jaksonTila = !Boolean.TRUE.equals(student.getArchived()) ? OpiskeluoikeudenTila.lasna : OpiskeluoikeudenTila.mitatoity;
+    OpiskeluoikeusJakso jakso = new OpiskeluoikeusJakso(student.getStudyStartDate(), jaksonTila);
     jakso.setOpintojenRahoitus(new KoodistoViite<>(student.getSchool() == null ? OpintojenRahoitus.K1 : OpintojenRahoitus.K6));
     opiskeluoikeus.getTila().addOpiskeluoikeusJakso(jakso);
 

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/ListKoskiPersonLogEntriesJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/ListKoskiPersonLogEntriesJSONRequestController.java
@@ -122,7 +122,7 @@ public class ListKoskiPersonLogEntriesJSONRequestController extends JSONRequestC
   }
   
   public UserRole[] getAllowedRoles() {
-    return new UserRole[] { UserRole.ADMINISTRATOR, UserRole.MANAGER };
+    return new UserRole[] { UserRole.ADMINISTRATOR, UserRole.MANAGER, UserRole.STUDY_PROGRAMME_LEADER };
   }
 
 }

--- a/pyramus/src/main/webapp/scripts/gui/students/koski.js
+++ b/pyramus/src/main/webapp/scripts/gui/students/koski.js
@@ -23,6 +23,9 @@ function loadLogEntries(personId) {
         }
       }
       $('koski-status').addClassName('koski-' + status.toLowerCase());
+    },
+    onFailure: function() {
+      // Not that critical to do anything
     }
   });
 }


### PR DESCRIPTION
If a students gets archived Koski is informed by invalidating (mitatoity state) the archived student. However it is a bit annoying as you get one chance to report it after which Koski doesn't want to receive the invalidated oid ever again so it needs to be cleared if the save was successful.

Also added permission for study programme leaders to list Koski state for students.

Closes #675 
Closes #677 