### PR TITLE
Fixed issues with isAllowedEmail and calls to it

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/UserUtils.java
@@ -3,6 +3,8 @@ package fi.otavanopisto.pyramus.framework;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.otavanopisto.pyramus.dao.DAOFactory;
 import fi.otavanopisto.pyramus.dao.students.StudentDAO;
 import fi.otavanopisto.pyramus.dao.users.StaffMemberDAO;
@@ -37,14 +39,19 @@ public class UserUtils {
    * @param contactType contacttype for emailAddress, if contacttype is non-unique, this methods returns always true
    * @param personId id of person receiving this address
    * @return true if email may be used by the provided person
+   * @throws IllegalArgumentException if the given email is blank 
    */
   public static boolean isAllowedEmail(String emailAddress, ContactType contactType, Long personId) {
+    if (StringUtils.isBlank(emailAddress)) {
+      throw new IllegalArgumentException("Email address cannot be blank.");
+    }
+    
     // if Email is being put into non-unique field, it is always allowed    
     if (contactType.getNonUnique())
       return true;
     
-    emailAddress = emailAddress != null ? emailAddress.trim() : null;
-    
+    emailAddress = StringUtils.trim(emailAddress);
+
     StaffMemberDAO staffMemberDAO = DAOFactory.getInstance().getStaffMemberDAO();
     StudentDAO studentDAO = DAOFactory.getInstance().getStudentDAO();
 

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/CreateStudentJSONRequestController.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import fi.internetix.smvc.controllers.JSONRequestContext;
 import fi.otavanopisto.pyramus.I18N.Messages;
@@ -79,9 +79,10 @@ public class CreateStudentJSONRequestController extends JSONRequestController {
     int emailCount2 = requestContext.getInteger("emailTable.rowCount");
     for (int i = 0; i < emailCount2; i++) {
       String colPrefix = "emailTable." + i;
-      String email = requestContext.getString(colPrefix + ".email");
-      ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-      if (email != null) {
+      String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
+      if (StringUtils.isNotBlank(email)) {
+        ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
+        
         if (!UserUtils.isAllowedEmail(email, contactType, personId)) {
           throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
         }
@@ -222,12 +223,9 @@ public class CreateStudentJSONRequestController extends JSONRequestController {
       String colPrefix = "emailTable." + i;
       Boolean defaultAddress = requestContext.getBoolean(colPrefix + ".defaultAddress");
       ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-      String email = requestContext.getString(colPrefix + ".email");
+      String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
       
-      // Trim the email address
-      email = email != null ? email.trim() : null;
-
-      if (email != null) {
+      if (StringUtils.isNotBlank(email)) {
         emailDAO.create(student.getContactInfo(), contactType, defaultAddress, email);
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
@@ -174,7 +174,7 @@ public class EditStudentJSONRequestController extends JSONRequestController {
       int rowCount = requestContext.getInteger("emailTable." + student.getId() + ".rowCount");
       for (int i = 0; i < rowCount; i++) {
         String colPrefix = "emailTable." + student.getId() + "." + i;
-        String email = requestContext.getString(colPrefix + ".email");
+        String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
         if (StringUtils.isNotBlank(email)) {
           ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
           

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.hibernate.StaleObjectStateException;
 
@@ -175,9 +175,12 @@ public class EditStudentJSONRequestController extends JSONRequestController {
       for (int i = 0; i < rowCount; i++) {
         String colPrefix = "emailTable." + student.getId() + "." + i;
         String email = requestContext.getString(colPrefix + ".email");
-        ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-        if (StringUtils.isNotBlank(email) && !UserUtils.isAllowedEmail(email, contactType, person.getId()))
-          throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
+        if (StringUtils.isNotBlank(email)) {
+          ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
+          
+          if (!UserUtils.isAllowedEmail(email, contactType, person.getId()))
+            throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
+        }
       }
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/CreateUserJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/CreateUserJSONRequestController.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import fi.internetix.smvc.SmvcRuntimeException;
 import fi.internetix.smvc.controllers.JSONRequestContext;
@@ -59,9 +59,10 @@ public class CreateUserJSONRequestController extends JSONRequestController {
     int emailCount2 = requestContext.getInteger("emailTable.rowCount");
     for (int i = 0; i < emailCount2; i++) {
       String colPrefix = "emailTable." + i;
-      String email = requestContext.getString(colPrefix + ".email");
-      ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-      if (email != null) {
+      String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
+      if (StringUtils.isNotBlank(email)) {
+        ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
+        
         if (!UserUtils.isAllowedEmail(email, contactType, personId)) {
           throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
         }
@@ -151,12 +152,9 @@ public class CreateUserJSONRequestController extends JSONRequestController {
       String colPrefix = "emailTable." + i;
       Boolean defaultAddress = requestContext.getBoolean(colPrefix + ".defaultAddress");
       ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-      String email = requestContext.getString(colPrefix + ".email");
+      String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
       
-      // Trim the email address
-      email = email != null ? email.trim() : null;
-
-      if (email != null) {
+      if (StringUtils.isNotBlank(email)) {
         emailDAO.create(user.getContactInfo(), contactType, defaultAddress, email);
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/EditUserJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/users/EditUserJSONRequestController.java
@@ -81,11 +81,14 @@ public class EditUserJSONRequestController extends JSONRequestController {
     int emailCount2 = requestContext.getInteger("emailTable.rowCount");
     for (int i = 0; i < emailCount2; i++) {
       String colPrefix = "emailTable." + i;
-      String email = requestContext.getString(colPrefix + ".email");
-      ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-
-      if (!UserUtils.isAllowedEmail(email, contactType, user.getPerson().getId()))
-        throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
+      String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
+      if (StringUtils.isNotBlank(email)) {
+        ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
+  
+        if (!UserUtils.isAllowedEmail(email, contactType, user.getPerson().getId())) {
+          throw new RuntimeException(Messages.getInstance().getText(requestContext.getRequest().getLocale(), "generic.errors.emailInUse"));
+        }
+      }
     }
     
     Set<Tag> tagEntities = new HashSet<>();
@@ -161,10 +164,7 @@ public class EditUserJSONRequestController extends JSONRequestController {
       String colPrefix = "emailTable." + i;
       Boolean defaultAddress = requestContext.getBoolean(colPrefix + ".defaultAddress");
       ContactType contactType = contactTypeDAO.findById(requestContext.getLong(colPrefix + ".contactTypeId"));
-      String email = requestContext.getString(colPrefix + ".email");
-
-      // Trim the email address
-      email = email != null ? email.trim() : null;
+      String email = StringUtils.trim(requestContext.getString(colPrefix + ".email"));
 
       Long emailId = requestContext.getLong(colPrefix + ".emailId");
       if (emailId == -1 && email != null) {

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/CommonController.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/CommonController.java
@@ -6,6 +6,8 @@ import javax.ejb.Stateless;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.otavanopisto.pyramus.dao.base.AddressDAO;
 import fi.otavanopisto.pyramus.dao.base.BillingDetailsDAO;
 import fi.otavanopisto.pyramus.dao.base.ContactTypeDAO;
@@ -350,8 +352,12 @@ public class CommonController {
   // TODO: allowed email check is better handled when email is created through staffmember or student, maybe it should be always context-aware creation
   public Email createEmail(ContactInfo contactInfo, ContactType contactType, Boolean defaultAddress, String address) {
     // Trim the email address
-    address = address != null ? address.trim() : null;
+    address = StringUtils.trim(address);
 
+    if (StringUtils.isBlank(address)) {
+      throw new IllegalArgumentException("Address cannot be blank");
+    }
+    
     if (!UserUtils.isAllowedEmail(address, contactType))
       throw new RuntimeException("Email address is in use.");
 

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/StudentController.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/StudentController.java
@@ -9,6 +9,8 @@ import javax.ejb.Stateless;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.otavanopisto.pyramus.dao.base.AddressDAO;
 import fi.otavanopisto.pyramus.dao.base.ContactInfoDAO;
 import fi.otavanopisto.pyramus.dao.base.ContactURLDAO;
@@ -241,8 +243,12 @@ public class StudentController {
 
   public Email addStudentEmail(Student student, ContactType contactType, String address, Boolean defaultAddress) throws UserEmailInUseException {
     // Trim the email address
-    address = address != null ? address.trim() : null;
+    address = StringUtils.trim(address);
 
+    if (StringUtils.isBlank(address)) {
+      throw new IllegalArgumentException("Email cannot be blank.");
+    }
+    
     if (!UserUtils.isAllowedEmail(address, contactType, student.getPerson().getId()))
       throw new UserEmailInUseException();
     

--- a/webservices-plugin/src/main/java/fi/pyramus/services/StudentsService.java
+++ b/webservices-plugin/src/main/java/fi/pyramus/services/StudentsService.java
@@ -10,7 +10,7 @@ import javax.jws.WebService;
 import javax.persistence.EnumType;
 import javax.xml.ws.BindingType;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import fi.otavanopisto.pyramus.dao.DAOFactory;
 import fi.otavanopisto.pyramus.dao.base.AddressDAO;
@@ -372,16 +372,18 @@ public class StudentsService extends PyramusService {
     ContactTypeDAO contactTypeDAO = DAOFactory.getInstance().getContactTypeDAO();
     Student student = studentDAO.findById(studentId);
     
-    address = address != null ? address.trim() : null;
+    address = StringUtils.trim(address);
     
-    // TODO contactType
-    ContactType contactType = contactTypeDAO.findById(new Long(1));
-
-    if (!UserUtils.isAllowedEmail(address, contactType, student.getPerson().getId()))
-      throw new RuntimeException("Email address is in use");
-
-    Email email = emailDAO.create(student.getContactInfo(), contactType, defaultAddress, address);
-    validateEntity(email);
+    if (StringUtils.isNotBlank(address)) {
+      // TODO contactType
+      ContactType contactType = contactTypeDAO.findById(new Long(1));
+  
+      if (!UserUtils.isAllowedEmail(address, contactType, student.getPerson().getId()))
+        throw new RuntimeException("Email address is in use");
+  
+      Email email = emailDAO.create(student.getContactInfo(), contactType, defaultAddress, address);
+      validateEntity(email);
+    }
   }
 
   public void archiveStudent(@WebParam (name="studentId") Long studentId) {

--- a/webservices-plugin/src/main/java/fi/pyramus/services/UsersService.java
+++ b/webservices-plugin/src/main/java/fi/pyramus/services/UsersService.java
@@ -7,6 +7,8 @@ import javax.jws.WebService;
 import javax.persistence.EnumType;
 import javax.xml.ws.BindingType;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.otavanopisto.pyramus.dao.DAOFactory;
 import fi.otavanopisto.pyramus.dao.base.ContactTypeDAO;
 import fi.otavanopisto.pyramus.dao.base.EmailDAO;
@@ -94,16 +96,18 @@ public class UsersService extends PyramusService {
     StaffMember user = userDAO.findById(userId);
     
     // Trim the email address
-    address = address != null ? address.trim() : null;
+    address = StringUtils.trim(address);
 
-    // TODO contact type, default address
-    ContactType contactType = contactTypeDAO.findById(new Long(1));
-
-    if (!UserUtils.isAllowedEmail(address, contactType, user.getPerson().getId()))
-      throw new RuntimeException("Email address is in use");
-
-    Email email = emailDAO.create(user.getContactInfo(), contactType, Boolean.TRUE, address);
-    validateEntity(email);
+    if (StringUtils.isNotBlank(address)) {
+      // TODO contact type, default address
+      ContactType contactType = contactTypeDAO.findById(new Long(1));
+  
+      if (!UserUtils.isAllowedEmail(address, contactType, user.getPerson().getId()))
+        throw new RuntimeException("Email address is in use");
+  
+      Email email = emailDAO.create(user.getContactInfo(), contactType, Boolean.TRUE, address);
+      validateEntity(email);
+    }
   }
 
   public void removeUserEmail(@WebParam(name = "userId") Long userId, @WebParam(name = "address") String address) {


### PR DESCRIPTION
Edit user view crashed when email field was empty. The main problem was that isAllowedEmail didn't check if the supplied email was blank and just happily listed students with null email (alot of them!) and later just crashed to NPE when comparing the emails.

Fixed by adding checks for the parameters to be correctly supplied and checking for blank emails given from UI. Also cleaned up nearby code related to the issue.

Closes #751