### PR TITLE
Fixes NPE by enforcing the caller to define existing variablekeys

### DIFF
--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/StudentRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/StudentRESTService.java
@@ -1397,6 +1397,10 @@ public class StudentRESTService extends AbstractRESTService {
       return Response.status(Status.BAD_REQUEST).build();
     }
 
+    if (!userController.checkUserVariableKeysExist(entity.getVariables().keySet())) {
+      return Response.status(Status.BAD_REQUEST).build();
+    }
+
     StudentActivityType activityType = entity.getActivityTypeId() != null ? studentActivityTypeController.findStudentActivityTypeById(entity
         .getActivityTypeId()) : null;
     StudentExaminationType examinationType = entity.getExaminationTypeId() != null ? studentExaminationTypeController.findStudentExaminationTypeById(entity
@@ -1517,6 +1521,10 @@ public class StudentRESTService extends AbstractRESTService {
 
     StudyProgramme studyProgramme = studyProgrammeController.findStudyProgrammeById(studyProgrammeId);
     if (studyProgramme == null) {
+      return Response.status(Status.BAD_REQUEST).build();
+    }
+    
+    if (!userController.checkUserVariableKeysExist(entity.getVariables().keySet())) {
       return Response.status(Status.BAD_REQUEST).build();
     }
 

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/UserController.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/UserController.java
@@ -1,5 +1,6 @@
 package fi.otavanopisto.pyramus.rest.controller;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -123,7 +124,23 @@ public class UserController {
     return user;
   }
   
+  public boolean checkUserVariableKeysExist(Collection<String> variableKeys) {
+    if (variableKeys != null) {
+      for (String variableKeyName : variableKeys) {
+        if (userVariableKeyDAO.findByVariableKey(variableKeyName) == null) {
+          return false;
+        }
+      }
+    }
+    
+    return true;
+  }
+  
   public UserVariable createUserVariable(User user, UserVariableKey key, String value) {
+    if (key == null) {
+      throw new IllegalArgumentException("UserVariableKey cannot be null");
+    }
+    
     return userVariableDAO.create(user, key, value);
   }
 


### PR DESCRIPTION
Issue: caller defines keys that don't exist -> updateUserVariables ends up creating an uservariable with null key(!). NPE comes from REST at the time when variables are enumerated to Student object. (Glad it forces a rollback or we'd have uservariables with null keys in db.)

Closes #723 