### PR TITLE
Applications: Always allow transferring as student

### DIFF
--- a/pyramus/src/main/webapp/templates/applications/management-fragment-actions.jsp
+++ b/pyramus/src/main/webapp/templates/applications/management-fragment-actions.jsp
@@ -13,11 +13,7 @@
       <span class="application-handling-text">Allekirjoita hyv‰ksynt‰</span>
     </div>
     <div class="application-handling-option accept-action" data-state="APPROVED_BY_SCHOOL" data-show="STAFF_SIGNED"><span class="application-handling-text">Ilmoita hyv‰ksymisest‰</span></div>
-    <div class="application-handling-option accept-action" data-line="nettilukio" data-state="TRANSFERRED_AS_STUDENT" data-show="APPROVED_BY_SCHOOL,APPROVED_BY_APPLICANT"><span class="application-handling-text">Siirr‰ opiskelijaksi</span></div>
-    <div class="application-handling-option accept-action" data-line="nettipk" data-state="TRANSFERRED_AS_STUDENT" data-show="APPROVED_BY_SCHOOL,APPROVED_BY_APPLICANT"><span class="application-handling-text">Siirr‰ opiskelijaksi</span></div>
-    <div class="application-handling-option accept-action" data-line="aikuislukio" data-state="TRANSFERRED_AS_STUDENT" data-show="PROCESSING,APPROVED_BY_SCHOOL,APPROVED_BY_APPLICANT"><span class="application-handling-text">Siirr‰ opiskelijaksi</span></div>
-    <div class="application-handling-option accept-action" data-line="mk" data-state="TRANSFERRED_AS_STUDENT" data-show="PROCESSING,APPROVED_BY_SCHOOL,APPROVED_BY_APPLICANT"><span class="application-handling-text">Siirr‰ opiskelijaksi</span></div>
-    <div class="application-handling-option accept-action" data-line="aineopiskelu" data-state="TRANSFERRED_AS_STUDENT" data-show="PROCESSING"><span class="application-handling-text">Siirr‰ opiskelijaksi</span></div>
+    <div class="application-handling-option accept-action" data-state="TRANSFERRED_AS_STUDENT" data-show="PROCESSING,STAFF_SIGNED,APPROVED_BY_SCHOOL,APPROVED_BY_APPLICANT"><span class="application-handling-text">Siirr‰ opiskelijaksi</span></div>
     <div class="application-handling-option accept-action" data-line="aineopiskelu" data-state="REGISTRATION_CHECKED" data-show="REGISTERED_AS_STUDENT"><span class="application-handling-text">Kuittaa tarkistetuksi</span></div>    
     <div class="application-handling-option decline-action" data-state="REJECTED" data-show="PROCESSING,APPROVED_BY_SCHOOL,REGISTERED_AS_STUDENT"><span class="application-handling-text decline-application">Hylk‰‰ hakemus</span></div>
     <div class="application-handling-option delete-action" data-state="ARCHIVE" data-show="PROCESSING"><span class="application-handling-text archive-application">Poista hakemus</span></div>


### PR DESCRIPTION
- resolves #892

After grooming, it was decided that no matter the applicant's age or line, transferring as student should always be an option just like following the formal approval procedure is.