### PR TITLE
Changes to YTL JSON generation

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/ytl/YTLAineKoodi.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/ytl/YTLAineKoodi.java
@@ -1,7 +1,9 @@
 package fi.otavanopisto.pyramus.ytl;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -61,10 +63,19 @@ public class YTLAineKoodi {
     return ytlAine + (StringUtils.isNotBlank(ytlOppimäärä) ? ytlOppimäärä : "");
   }
   
+  public Set<String> getSuoritetutKurssitLisäaineet() {
+    return suoritetutKurssitLisäaineet;
+  }
+
+  public void setSuoritetutKurssitLisäaineet(Set<String> suoritetutKurssitLisäaineet) {
+    this.suoritetutKurssitLisäaineet = suoritetutKurssitLisäaineet;
+  }
+
   private String ytlAine;
   private String ytlOppimäärä;
   private String aine;
   private String aineKoodi;
   private MatriculationExamSubject matriculationExamSubject;
   private List<YTLAineKoodiSuoritettuKurssi> suoritetutKurssit = new ArrayList<>();
+  private Set<String> suoritetutKurssitLisäaineet = new HashSet<>();
 }

--- a/framework/src/main/resources/fi/otavanopisto/pyramus/ytl/ytl_ainekoodit.json
+++ b/framework/src/main/resources/fi/otavanopisto/pyramus/ytl/ytl_ainekoodit.json
@@ -26,10 +26,9 @@
     "aineKoodi": "MAA",
     "matriculationExamSubject": "MAA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "MAY" },
-      { "educationType": "2", "subjectCode": "MAA" },
-      { "educationType": "2", "subjectCode": "MAB" }
-    ]
+      { "educationType": "2", "subjectCode": "MAA" }
+    ],
+    "suoritetutKurssitLisäaineet": ["N"]
   },
   {
     "ytlAine": "N",
@@ -38,10 +37,9 @@
     "aineKoodi": "MAB",
     "matriculationExamSubject": "MAB",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "MAY" },
-      { "educationType": "2", "subjectCode": "MAA" },
       { "educationType": "2", "subjectCode": "MAB" }
-    ]
+    ],
+    "suoritetutKurssitLisäaineet": ["M"]
   },
 
   {
@@ -51,11 +49,7 @@
     "aineKoodi": "RUA",
     "matriculationExamSubject": "RUA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "RUA" },
-      { "educationType": "2", "subjectCode": "RUB" },
-      { "educationType": "2", "subjectCode": "RUB1" },
-      { "educationType": "2", "subjectCode": "RUB3" },
-      { "educationType": "2", "subjectCode": "RUC" }
+      { "educationType": "2", "subjectCode": "RUA" }
     ]
   },
   {
@@ -65,11 +59,9 @@
     "aineKoodi": "RUB",
     "matriculationExamSubject": "RUB",
       "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "RUA" },
       { "educationType": "2", "subjectCode": "RUB" },
       { "educationType": "2", "subjectCode": "RUB1" },
-      { "educationType": "2", "subjectCode": "RUB3" },
-      { "educationType": "2", "subjectCode": "RUC" }
+      { "educationType": "2", "subjectCode": "RUB3" }
     ]
   },
   {
@@ -79,9 +71,7 @@
     "aineKoodi": "ENA",
     "matriculationExamSubject": "ENA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "ENA" },
-      { "educationType": "2", "subjectCode": "ENB" },
-      { "educationType": "2", "subjectCode": "ENC" }
+      { "educationType": "2", "subjectCode": "ENA" }
     ]
   },
   {
@@ -91,8 +81,6 @@
     "aineKoodi": "ENC",
     "matriculationExamSubject": "ENC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "ENA" },
-      { "educationType": "2", "subjectCode": "ENB" },
       { "educationType": "2", "subjectCode": "ENC" }
     ]
   },
@@ -103,9 +91,7 @@
     "aineKoodi": "RAA",
     "matriculationExamSubject": "RAA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "RAA" },
-      { "educationType": "2", "subjectCode": "RAB" },
-      { "educationType": "2", "subjectCode": "RAC" }
+      { "educationType": "2", "subjectCode": "RAA" }
     ]
   },
   {
@@ -115,8 +101,6 @@
     "aineKoodi": "RAC",
     "matriculationExamSubject": "RAC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "RAA" },
-      { "educationType": "2", "subjectCode": "RAB" },
       { "educationType": "2", "subjectCode": "RAC" }
     ]
   },
@@ -127,9 +111,7 @@
     "aineKoodi": "ESA",
     "matriculationExamSubject": "ESA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "ESA" },
-      { "educationType": "2", "subjectCode": "ESB" },
-      { "educationType": "2", "subjectCode": "ESC" }
+      { "educationType": "2", "subjectCode": "ESA" }
     ]
   },
   {
@@ -139,8 +121,6 @@
     "aineKoodi": "ESC",
     "matriculationExamSubject": "ESC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "ESA" },
-      { "educationType": "2", "subjectCode": "ESB" },
       { "educationType": "2", "subjectCode": "ESC" }
     ]
   },
@@ -151,9 +131,7 @@
     "aineKoodi": "SAA",
     "matriculationExamSubject": "SAA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "SAA" },
-      { "educationType": "2", "subjectCode": "SAB" },
-      { "educationType": "2", "subjectCode": "SAC" }
+      { "educationType": "2", "subjectCode": "SAA" }
     ]
   },
   {
@@ -163,8 +141,6 @@
     "aineKoodi": "SAC",
     "matriculationExamSubject": "SAC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "SAA" },
-      { "educationType": "2", "subjectCode": "SAB" },
       { "educationType": "2", "subjectCode": "SAC" }
     ]
   },
@@ -175,9 +151,7 @@
     "aineKoodi": "VEA",
     "matriculationExamSubject": "VEA",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "VEA" },
-      { "educationType": "2", "subjectCode": "VEB" },
-      { "educationType": "2", "subjectCode": "VEC" }
+      { "educationType": "2", "subjectCode": "VEA" }
     ]
   },
   {
@@ -187,8 +161,6 @@
     "aineKoodi": "VEC",
     "matriculationExamSubject": "VEC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "VEA" },
-      { "educationType": "2", "subjectCode": "VEB" },
       { "educationType": "2", "subjectCode": "VEC" }
     ]
   },
@@ -199,8 +171,6 @@
     "aineKoodi": "ITC",
     "matriculationExamSubject": "ITC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "ITA" },
-      { "educationType": "2", "subjectCode": "ITB" },
       { "educationType": "2", "subjectCode": "ITC" }
     ]
   },
@@ -211,8 +181,6 @@
     "aineKoodi": "POC",
     "matriculationExamSubject": "POC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "POA" },
-      { "educationType": "2", "subjectCode": "POB" },
       { "educationType": "2", "subjectCode": "POC" }
     ]
   },
@@ -223,8 +191,6 @@
     "aineKoodi": "LAC",
     "matriculationExamSubject": "LAC",
     "suoritetutKurssit": [
-      { "educationType": "2", "subjectCode": "LAA" },
-      { "educationType": "2", "subjectCode": "LAB" },
       { "educationType": "2", "subjectCode": "LAC" }
     ]
   },


### PR DESCRIPTION
* Removed Äidinkieli code from pakollinen/ylimääräinen list
* Amounts of credited courses are reported by the level of the subject i.e. if student applied to subject E then EA and EC credit counts are added to the report
* Math has levels with different subject codes so they are cross referenced (M<->N)