### PR TITLE
Trying to fix blocked repositories

### DIFF
--- a/.mvn/local-settings.xml
+++ b/.mvn/local-settings.xml
@@ -1,0 +1,20 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <mirrors>
+      <mirror>
+          <id>otavanopisto-releases-http-unblocker</id>
+          <mirrorOf>otavanopisto-releases</mirrorOf>
+          <name></name>
+          <url>http://maven.otavanopisto.fi:7070/nexus/content/repositories/releases</url>
+          <blocked>false</blocked>
+      </mirror>
+      <mirror>
+        <id>otavanopisto-snapshots-http-unblocker</id>
+        <mirrorOf>otavanopisto-snapshots</mirrorOf>
+        <name></name>
+        <url>http://maven.otavanopisto.fi:7070/nexus/content/repositories/snapshots</url>
+        <blocked>false</blocked>
+      </mirror>
+  </mirrors>
+</settings>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/local-settings.xml

--- a/pyramus/.mvn/local-settings.xml
+++ b/pyramus/.mvn/local-settings.xml
@@ -1,0 +1,20 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <mirrors>
+      <mirror>
+          <id>otavanopisto-releases-http-unblocker</id>
+          <mirrorOf>otavanopisto-releases</mirrorOf>
+          <name></name>
+          <url>http://maven.otavanopisto.fi:7070/nexus/content/repositories/releases</url>
+          <blocked>false</blocked>
+      </mirror>
+      <mirror>
+        <id>otavanopisto-snapshots-http-unblocker</id>
+        <mirrorOf>otavanopisto-snapshots</mirrorOf>
+        <name></name>
+        <url>http://maven.otavanopisto.fi:7070/nexus/content/repositories/snapshots</url>
+        <blocked>false</blocked>
+      </mirror>
+  </mirrors>
+</settings>

--- a/pyramus/.mvn/maven.config
+++ b/pyramus/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/local-settings.xml


### PR DESCRIPTION
New maven blocks calls to http repositories by default.
Solution derived from:
https://stackoverflow.com/questions/67001968/how-to-disable-maven-blocking-external-http-repositores

Cause of problem:
https://github.com/apache/maven/commit/907d53ad3264718f66ff15e1363d76b07dd0c05f