### PR TITLE
Cleanup of deprecated fields

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiSettings.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiSettings.java
@@ -234,6 +234,7 @@ public class KoskiSettings {
     return null;
   }
 
+  @Deprecated
   public boolean isFreeLodging(Long studyProgrammeId) {
     return freeLodgingStudyProgrammes.contains(studyProgrammeId);
   }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AbstractAikuistenPerusopetuksenHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AbstractAikuistenPerusopetuksenHandler.java
@@ -1,9 +1,6 @@
 package fi.otavanopisto.pyramus.koski.model.aikuistenperusopetus;
 
-import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -35,23 +32,9 @@ public abstract class AbstractAikuistenPerusopetuksenHandler extends KoskiStuden
   protected AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot getLisatiedot(Student student) {
     AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot lisatiedot = new AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot();
     
-    lisatiedot.setVuosiluokkiinSitoutumatonOpetus(true);
-    
     List<StudentLodgingPeriod> lodgingPeriods = lodgingPeriodDAO.listByStudent(student);
     for (StudentLodgingPeriod lodgingPeriod : lodgingPeriods) {
       lisatiedot.addSisaoppilaitosmainenMajoitus(new Majoitusjakso(lodgingPeriod.getBegin(), lodgingPeriod.getEnd()));
-    }
-    
-    if (!lodgingPeriods.isEmpty()) {
-      Date minBeginDate = lodgingPeriods.stream().map(StudentLodgingPeriod::getBegin).filter(Objects::nonNull)
-          .min(Comparator.nullsLast(Date::compareTo)).orElse(null);
-      
-      if (minBeginDate != null) {
-        Date maxEndDate = lodgingPeriods.stream().map(StudentLodgingPeriod::getEnd).filter(Objects::nonNull)
-            .max(Comparator.nullsLast(Date::compareTo)).orElse(null);
-        
-        lisatiedot.setOikeusMaksuttomaanAsuntolapaikkaan(new Majoitusjakso(minBeginDate, maxEndDate));
-      }
     }
     
     List<StudentStudyPeriod> studyPeriods = studentStudyPeriodDAO.listByStudent(student);

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot.java
@@ -25,32 +25,8 @@ public class AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot {
     return sisaoppilaitosmainenMajoitus;
   }
 
-  public List<Majoitusjakso> getUlkomailla() {
-    return ulkomailla;
-  }
-
-  public Boolean getVuosiluokkiinSitoutumatonOpetus() {
-    return vuosiluokkiinSitoutumatonOpetus;
-  }
-
-  public void setVuosiluokkiinSitoutumatonOpetus(Boolean vuosiluokkiinSitoutumatonOpetus) {
-    this.vuosiluokkiinSitoutumatonOpetus = vuosiluokkiinSitoutumatonOpetus;
-  }
-
-  public Boolean getVammainen() {
-    return vammainen;
-  }
-
-  public void setVammainen(Boolean vammainen) {
-    this.vammainen = vammainen;
-  }
-
-  public Boolean getVaikeastiVammainen() {
-    return vaikeastiVammainen;
-  }
-
-  public void setVaikeastiVammainen(Boolean vaikeastiVammainen) {
-    this.vaikeastiVammainen = vaikeastiVammainen;
+  public List<Majoitusjakso> getUlkomaanjaksot() {
+    return ulkomaanjaksot;
   }
 
   public Majoitusjakso getMajoitusetu() {
@@ -59,14 +35,6 @@ public class AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot {
 
   public void setMajoitusetu(Majoitusjakso majoitusetu) {
     this.majoitusetu = majoitusetu;
-  }
-
-  public Majoitusjakso getOikeusMaksuttomaanAsuntolapaikkaan() {
-    return oikeusMaksuttomaanAsuntolapaikkaan;
-  }
-
-  public void setOikeusMaksuttomaanAsuntolapaikkaan(Majoitusjakso oikeusMaksuttomaanAsuntolapaikkaan) {
-    this.oikeusMaksuttomaanAsuntolapaikkaan = oikeusMaksuttomaanAsuntolapaikkaan;
   }
 
   public void addOikeuttaMaksuttomuuteenPidennetty(OikeuttaMaksuttomuuteenPidennetty oikeuttaMaksuttomuuteenPidennetty) {
@@ -93,12 +61,8 @@ public class AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot {
     this.maksuttomuus = maksuttomuus;
   }
 
-  private Boolean vuosiluokkiinSitoutumatonOpetus;
-  private Boolean vammainen;
-  private Boolean vaikeastiVammainen;
-  private final List<Majoitusjakso> ulkomailla = new ArrayList<>();
+  private final List<Majoitusjakso> ulkomaanjaksot = new ArrayList<>();
   private Majoitusjakso majoitusetu;
-  private Majoitusjakso oikeusMaksuttomaanAsuntolapaikkaan;
   private final List<Majoitusjakso> sisaoppilaitosmainenMajoitus = new ArrayList<>();
   private List<Maksuttomuus> maksuttomuus = new ArrayList<>();
   private List<OikeuttaMaksuttomuuteenPidennetty> oikeuttaMaksuttomuuteenPidennetty = new ArrayList<>();

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/AbstractKoskiLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/AbstractKoskiLukioStudentHandler.java
@@ -5,14 +5,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
-
 import fi.otavanopisto.pyramus.dao.students.StudentStudyPeriodDAO;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
 import fi.otavanopisto.pyramus.domainmodel.students.StudentLodgingPeriod;
 import fi.otavanopisto.pyramus.domainmodel.students.StudentStudyPeriod;
 import fi.otavanopisto.pyramus.domainmodel.students.StudentStudyPeriodType;
-import fi.otavanopisto.pyramus.koski.KoskiConsts;
 import fi.otavanopisto.pyramus.koski.KoskiStudentHandler;
 import fi.otavanopisto.pyramus.koski.model.Majoitusjakso;
 
@@ -21,9 +18,6 @@ import fi.otavanopisto.pyramus.koski.model.Majoitusjakso;
  */
 public abstract class AbstractKoskiLukioStudentHandler extends KoskiStudentHandler {
 
-  public static final String USERVARIABLE_UNDER18START = KoskiConsts.UserVariables.STARTED_UNDER18;
-  public static final String USERVARIABLE_UNDER18STARTREASON = KoskiConsts.UserVariables.UNDER18_STARTREASON;
-
   @Inject
   private StudentStudyPeriodDAO studentStudyPeriodDAO;
   
@@ -31,18 +25,9 @@ public abstract class AbstractKoskiLukioStudentHandler extends KoskiStudentHandl
     List<StudentStudyPeriod> studyPeriods = studentStudyPeriodDAO.listByStudent(student);
     boolean pidennettyPaattymispaiva = studyPeriods.stream().anyMatch(studyPeriod -> studyPeriod.getPeriodType() == StudentStudyPeriodType.PROLONGED_STUDYENDDATE);
     boolean ulkomainenVaihtoopiskelija = false;
-    boolean yksityisopiskelija = settings.isYksityisopiskelija(student.getStudyProgramme().getId());
-    boolean oikeusMaksuttomaanAsuntolapaikkaan = settings.isFreeLodging(student.getStudyProgramme().getId());
     LukionOpiskeluoikeudenLisatiedot lisatiedot = new LukionOpiskeluoikeudenLisatiedot(
-        pidennettyPaattymispaiva, ulkomainenVaihtoopiskelija, yksityisopiskelija, oikeusMaksuttomaanAsuntolapaikkaan);
+        pidennettyPaattymispaiva, ulkomainenVaihtoopiskelija);
 
-    if (StringUtils.equals(userVariableDAO.findByUserAndKey(student, USERVARIABLE_UNDER18START), "1")) {
-      String under18startReason = userVariableDAO.findByUserAndKey(student, USERVARIABLE_UNDER18STARTREASON);
-      if (StringUtils.isNotBlank(under18startReason)) {
-        lisatiedot.setAlle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy(kuvaus(under18startReason));
-      }
-    }
-    
     List<StudentLodgingPeriod> lodgingPeriods = lodgingPeriodDAO.listByStudent(student);
     for (StudentLodgingPeriod lodgingPeriod : lodgingPeriods) {
       Majoitusjakso jakso = new Majoitusjakso(lodgingPeriod.getBegin(), lodgingPeriod.getEnd());

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/LukionOpiskeluoikeudenLisatiedot.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/LukionOpiskeluoikeudenLisatiedot.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import fi.otavanopisto.pyramus.koski.model.Kuvaus;
 import fi.otavanopisto.pyramus.koski.model.Majoitusjakso;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,20 +16,9 @@ public class LukionOpiskeluoikeudenLisatiedot {
   public LukionOpiskeluoikeudenLisatiedot() {
   }
   
-  public LukionOpiskeluoikeudenLisatiedot(boolean pidennettyPaattymispaiva, boolean ulkomainenVaihtoopiskelija, boolean yksityisopiskelija, boolean oikeusMaksuttomaanAsuntolapaikkaan) {
+  public LukionOpiskeluoikeudenLisatiedot(boolean pidennettyPaattymispaiva, boolean ulkomainenVaihtoopiskelija) {
     this.pidennettyPaattymispaiva = pidennettyPaattymispaiva;
     this.ulkomainenVaihtoopiskelija = ulkomainenVaihtoopiskelija;
-    this.yksityisopiskelija = yksityisopiskelija;
-    this.oikeusMaksuttomaanAsuntolapaikkaan = oikeusMaksuttomaanAsuntolapaikkaan;
-  }
-  
-  public Kuvaus getAlle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy() {
-    return alle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy;
-  }
-  
-  public void setAlle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy(
-      Kuvaus alle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy) {
-    this.alle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy = alle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy;
   }
   
   @JsonProperty("pidennettyPäättymispäivä")
@@ -42,15 +30,6 @@ public class LukionOpiskeluoikeudenLisatiedot {
     return ulkomainenVaihtoopiskelija;
   }
   
-  @Deprecated
-  public boolean isYksityisopiskelija() {
-    return yksityisopiskelija;
-  }
-  
-  public boolean isOikeusMaksuttomaanAsuntolapaikkaan() {
-    return oikeusMaksuttomaanAsuntolapaikkaan;
-  }
-
   public void addSisaoppilaitosmainenMajoitus(Majoitusjakso jakso) {
     sisaoppilaitosmainenMajoitus.add(jakso);
   }
@@ -66,15 +45,6 @@ public class LukionOpiskeluoikeudenLisatiedot {
 
   public void setUlkomainenVaihtoopiskelija(boolean ulkomainenVaihtoopiskelija) {
     this.ulkomainenVaihtoopiskelija = ulkomainenVaihtoopiskelija;
-  }
-
-  @Deprecated
-  public void setYksityisopiskelija(boolean yksityisopiskelija) {
-    this.yksityisopiskelija = yksityisopiskelija;
-  }
-
-  public void setOikeusMaksuttomaanAsuntolapaikkaan(boolean oikeusMaksuttomaanAsuntolapaikkaan) {
-    this.oikeusMaksuttomaanAsuntolapaikkaan = oikeusMaksuttomaanAsuntolapaikkaan;
   }
 
   public void setSisaoppilaitosmainenMajoitus(List<Majoitusjakso> sisaoppilaitosmainenMajoitus) {
@@ -107,9 +77,6 @@ public class LukionOpiskeluoikeudenLisatiedot {
 
   private boolean pidennettyPaattymispaiva;
   private boolean ulkomainenVaihtoopiskelija;
-  private Kuvaus alle18vuotiaanAikuistenLukiokoulutuksenAloittamisenSyy;
-  @Deprecated private boolean yksityisopiskelija;
-  private boolean oikeusMaksuttomaanAsuntolapaikkaan;
   private List<Majoitusjakso> sisaoppilaitosmainenMajoitus = new ArrayList<>();
   private List<Maksuttomuus> maksuttomuus = new ArrayList<>();
   private List<OikeuttaMaksuttomuuteenPidennetty> oikeuttaMaksuttomuuteenPidennetty = new ArrayList<>();


### PR DESCRIPTION
**Käytöstä poistetut lisätiedot**

**Aikuisten perusopetus**

- oikeus maksuttomaan asuntolapaikkaan – ei olennainen tieto
- tehostetun tuen päätökset – ei olennainen tieto aikuisten perusopetuksessa
- tukimuodot – ei olennainen tieto aikuisten perusopetuksessa
- vuosiluokkiin sitomaton opetus– ei olennainen tieto aikuisten perusopetuksessa
- muu kuin vaikeimmin kehitysvammainen – ei olennainen tieto aikuisten perusopetuksessa
- vaikeimmin kehitysvammainen – ei olennainen tieto aikuisten perusopetuksessa
- 

**Lukiokoulutus ja IB**

- oikeus maksuttomaan asuntolapaikkaan – ei olennainen tieto
- alle 18-vuotiaan aikuisten lukiokoulutuksen aloittamisen syy – Valtionosuudet tarvittaessa pyytää koulutuksen järjestäjältä perusteet
- yksityisopiskelija – ei olennainen tieto lukiokoulutuksessa