### PR TITLE
Don't show latest grade as raised if it's a non-passing grade

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/CourseAssessmentDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/CourseAssessmentDAO.java
@@ -248,7 +248,7 @@ public class CourseAssessmentDAO extends PyramusEntityDAO<CourseAssessment> {
   
   public CourseAssessment findLatestByCourseStudentAndCourseModuleAndArchived(CourseStudent courseStudent, CourseModule courseModule, Boolean archived) {
     List<CourseAssessment> courseAssessments = listByCourseStudentAndCourseModuleAndArchived(courseStudent, courseModule, archived);
-    courseAssessments.sort(Comparator.comparing(CourseAssessment::getDate).reversed());
+    courseAssessments.sort(Comparator.comparing(CourseAssessment::getDate).thenComparing(CourseAssessment::getId).reversed());
     return courseAssessments.isEmpty() ? null : courseAssessments.get(0);
   }
   

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/grading/SaveCourseAssessmentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/grading/SaveCourseAssessmentJSONRequestController.java
@@ -29,7 +29,6 @@ public class SaveCourseAssessmentJSONRequestController extends JSONRequestContro
     
     for (CourseModule courseModule : courseStudent.getCourse().getCourseModules()) {
       Long courseModuleId = courseModule.getId();
-      Date assessmentDate = jsonRequestContext.getDate("assessmentDate." + courseModuleId);
       Long assessingUserId = jsonRequestContext.getLong("assessingUserId." + courseModuleId);
       Long gradeId = jsonRequestContext.getLong("gradeId." + courseModuleId);
       String verbalAssessment = jsonRequestContext.getString("verbalAssessment." + courseModuleId);
@@ -37,13 +36,13 @@ public class SaveCourseAssessmentJSONRequestController extends JSONRequestContro
       StaffMember assessingUser = staffMemberDAO.findById(assessingUserId);
       Grade grade = gradeId == null ? null : gradeDAO.findById(gradeId);
 
-      if (grade != null && assessmentDate != null && assessingUser != null) {
+      if (grade != null && assessingUser != null) {
         CourseAssessment courseAssessment = courseAssessmentDAO.findLatestByCourseStudentAndCourseModuleAndArchived(courseStudent, courseModule, Boolean.FALSE);
         if (courseAssessment == null) {
-          courseAssessment = courseAssessmentDAO.create(courseStudent, courseModule, assessingUser, grade, assessmentDate, verbalAssessment);
+          courseAssessment = courseAssessmentDAO.create(courseStudent, courseModule, assessingUser, grade, new Date(), verbalAssessment);
         }
         else {
-          courseAssessment = courseAssessmentDAO.update(courseAssessment, assessingUser, grade, assessmentDate, verbalAssessment);
+          courseAssessment = courseAssessmentDAO.update(courseAssessment, assessingUser, grade, courseAssessment.getDate(), verbalAssessment);
         }
       }
     }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentViewController.java
@@ -446,6 +446,7 @@ public class ViewStudentViewController extends PyramusViewController2 implements
             .collect(Collectors.toList());
           
           if (CollectionUtils.isNotEmpty(courseAssessmentList) && courseModule.getCourse() != null) {
+            courseAssessmentList.sort(Comparator.comparing(CourseAssessment::getDate).thenComparing(CourseAssessment::getId));
             CourseBase course = courseModule.getCourse();
             
             JSONObject obj = new JSONObject();
@@ -477,6 +478,7 @@ public class ViewStudentViewController extends PyramusViewController2 implements
               assobj.put("gradeName", ass.getGrade() != null ? ass.getGrade().getName() : null);
               assobj.put("gradingScaleName", (ass.getGrade() != null && ass.getGrade().getGradingScale() != null) ? 
                   ass.getGrade().getGradingScale().getName() : null);
+              assobj.put("passing", ass.getGrade() != null ? ass.getGrade().getPassingGrade() : Boolean.FALSE);
               assobj.put("assessorName", ass.getAssessor() != null ? ass.getAssessor().getFullName() : null);
               jsonCourseAssessments.add(assobj);
             }

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
@@ -2373,7 +2373,6 @@ grading.courseAssessment.studyProgrammeNameTitle = Study Programme
 grading.courseAssessment.noStudyProgrammeTabLabel = No Study Programme
 grading.courseAssessment.courseNameTitle = Course
 grading.courseAssessment.assessingUserTitle = Assessing User
-grading.courseAssessment.assessmentDateTitle = Assessment Date
 grading.courseAssessment.gradeTitle = Grade
 grading.courseAssessment.verbalAssessmentTitle = Verbal Assessment
 grading.courseAssessment.saveButton = Save

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
@@ -2373,7 +2373,6 @@ grading.courseAssessment.studyProgrammeNameTitle = Koulutusohjelma
 grading.courseAssessment.noStudyProgrammeTabLabel = Ei koulutusohjelmaa
 grading.courseAssessment.courseNameTitle = Kurssi
 grading.courseAssessment.assessingUserTitle = Arvioija
-grading.courseAssessment.assessmentDateTitle = P\u00E4iv\u00E4m\u00E4\u00E4r\u00E4
 grading.courseAssessment.gradeTitle = Arvosana
 grading.courseAssessment.verbalAssessmentTitle = Kirjallinen arviointi
 grading.courseAssessment.saveButton = Tallenna

--- a/pyramus/src/main/webapp/templates/grading/courseassessment.jsp
+++ b/pyramus/src/main/webapp/templates/grading/courseassessment.jsp
@@ -25,9 +25,6 @@
         setupRelatedCommandsBasic();
         
         var entryForm = $("courseAssessmentForm");
-        var dField = getIxDateField("assessmentDate");
-        if ((dField != null) && (entryForm.assessmentDate.value == ""))
-          dField.setTimestamp(new Date().getTime());
       }
 
       function setupRelatedCommandsBasic() {
@@ -153,14 +150,6 @@
                 <span><img src="${pageContext.request.contextPath}/gfx/icons/16x16/actions/search.png" onclick="openSearchUsersDialog(${courseModule.id});"/></span>
               </div>
               
-              <div class="genericFormSection">  
-                <jsp:include page="/templates/generic/fragments/formtitle.jsp">
-                  <jsp:param name="titleLocale" value="grading.courseAssessment.assessmentDateTitle"/>
-                  <jsp:param name="helpLocale" value="grading.courseAssessment.assessmentDateHelp"/>
-                </jsp:include>
-                <input type="text" class="ixDateField" name="assessmentDate.${courseModule.id}" ix:datefieldid="assessmentDate.${courseModule.id}" value="${gradeDate}"/>
-              </div>
-  
               <div class="genericFormSection">  
                 <jsp:include page="/templates/generic/fragments/formtitle.jsp">
                   <jsp:param name="titleLocale" value="grading.courseAssessment.gradeTitle"/>

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -1360,7 +1360,9 @@
 
               if (studentAssessment.assessments.length > 1) {
                 gradeTooltip = "";
-                gradeExtraClass = "viewStudentRaisedGrade";
+                gradeExtraClass = studentAssessment.assessments[studentAssessment.assessments.length - 1].passing
+                    ? "viewStudentRaisedGrade"
+                    : "";
                 
                 for (var ai = 0; ai < studentAssessment.assessments.length; ai++) {
                   gradeTooltip = 
@@ -1370,7 +1372,7 @@
                     studentAssessment.assessments[ai].gradeName + 
                     "\n";
 
-                  if (studentAssessment.assessments[ai].timestamp > topAssessment.timestamp) {
+                  if (studentAssessment.assessments[ai].timestamp >= topAssessment.timestamp) {
                     topAssessment = studentAssessment.assessments[ai];
                   }
                 }


### PR DESCRIPTION
- removes assessment date from evaluation editor in order not to disturbe evaluation history
- more accurate sorting to determine latest grade
- resolves #1408