### PR TITLE
Usability fixes to student subject grades

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentSubjectGrade.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentSubjectGrade.java
@@ -105,7 +105,7 @@ public class StudentSubjectGrade {
   @Temporal (value=TemporalType.DATE)
   private Date gradeDate;
   
-  @ManyToOne
+  @ManyToOne (optional = false)
   @JoinColumn(name="gradeApprover")
   private StaffMember gradeApprover;
 

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale.properties
@@ -472,6 +472,9 @@ students.createStudent.lodgingPeriodsTable.begin = Begin
 students.createStudent.lodgingPeriodsTable.end = End
 students.createStudent.lodgingPeriodsTable.removeTooltip = Remove this lodging period
 
+students.viewStudent.subjectGrades.computedAverageGradeLabel = Avg
+students.viewStudent.subjectGrades.givenSubjectGradeLabel = Grade
+
 courses.generic.courseModulesTable.subjectHeader = Subject
 courses.generic.courseModulesTable.courseNumberHeader = Course Number
 courses.generic.courseModulesTable.courseLengthHeader = Length

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale_fi_FI.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale_fi_FI.properties
@@ -472,6 +472,9 @@ students.createStudent.lodgingPeriodsTable.begin = Alku
 students.createStudent.lodgingPeriodsTable.end = Loppu
 students.createStudent.lodgingPeriodsTable.removeTooltip = Poista tämä asumisjakso
 
+students.viewStudent.subjectGrades.computedAverageGradeLabel = ka.
+students.viewStudent.subjectGrades.givenSubjectGradeLabel = Ainearvosana
+
 courses.generic.courseModulesTable.subjectHeader = Oppiaine
 courses.generic.courseModulesTable.courseNumberHeader = Kurssinumero
 courses.generic.courseModulesTable.courseLengthHeader = Pituus

--- a/pyramus/src/main/webapp/templates/students/editstudentsubjectgradedialog.jsp
+++ b/pyramus/src/main/webapp/templates/students/editstudentsubjectgradedialog.jsp
@@ -47,8 +47,8 @@
             <jsp:param name="helpLocale" value="students.editStudentSubjectGradeDialog.gradeTitle"/>
           </jsp:include>
           
-          <select name="gradeId">
-            <option value=""><fmt:message key="students.editStudentSubjectGradeDialog.defaultGradeTitle"/></option>
+          <select name="gradeId" class="required">
+            <option value=""></option>
           
             <c:forEach var="gradingScale" items="${gradingScales}">
               <optgroup label="${fn:escapeXml(gradingScale.name)}">
@@ -72,7 +72,7 @@
             <jsp:param name="titleLocale" value="students.editStudentSubjectGradeDialog.gradeDateTitle"/>
             <jsp:param name="helpLocale" value="students.editStudentSubjectGradeDialog.gradeDateHelp"/>
           </jsp:include>
-          <input type="text" name="gradeDate" class="ixDateField" value="${fn:escapeXml(studentSubjectGrade.gradeDate.time)}"/>
+          <input type="text" name="gradeDate" class="ixDateField required" value="${fn:escapeXml(studentSubjectGrade.gradeDate.time)}"/>
         </div>
 
         <div class="genericFormSection">      
@@ -81,7 +81,7 @@
             <jsp:param name="helpLocale" value="students.editStudentSubjectGradeDialog.gradeApproverHelp"/>
           </jsp:include>
 
-          <select id="gradeApproverId" name="gradeApproverId">
+          <select id="gradeApproverId" name="gradeApproverId" class="required">
             <option></option>
             <c:forEach var="studyApprover" items="${studyApprovers}">
               <c:choose>

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -702,18 +702,18 @@
               pccElement.update("" + subject.passedCoursesCount);
               
               var subMeanContainer = subjectElement.appendChild(new Element("div", {className: "studentSubjectCreditsMeanGradeContainer"}));
+              var subMeanComputedGrade = subMeanContainer.appendChild(new Element("div", {className: "studentSubjectCreditsComputedMeanGrade"}));
               var subMeanGrade = subMeanContainer.appendChild(new Element("div", {
                 id: "studentSubjectCreditsMeanGrade." + studentId + "." + subject.id,
                 className: "studentSubjectCreditsMeanGrade"
               }));
-              var subMeanComputedGrade = subMeanContainer.appendChild(new Element("div", {className: "studentSubjectCreditsComputedMeanGrade"}));
 
               if (subject.meanGrade) {
-                subMeanGrade.update("" + subject.meanGrade.name);
+                subMeanGrade.update(getLocale().getText("students.viewStudent.subjectGrades.givenSubjectGradeLabel") + " " + subject.meanGrade.name);
               }
 
               if (subject.computedMeanGrade) {
-                subMeanComputedGrade.update("" + subject.computedMeanGrade);
+                subMeanComputedGrade.update(getLocale().getText("students.viewStudent.subjectGrades.computedAverageGradeLabel") + " " + subject.computedMeanGrade);
               }
 
               var subMeanEditButton = subMeanContainer.appendChild(new Element("img", {
@@ -734,7 +734,7 @@
         var subjectId = button.getAttribute("data-subjectId")
         
         var dialog = new IxDialog({
-          id : 'uploadReportDialog',
+          id : 'editStudentSubjectGradeDialog',
           contentURL : GLOBAL_contextPath + '/students/editstudentsubjectgradedialog.page?studentId=' + studentId + '&subjectId=' + subjectId,
           centered : true,
           showOk : true,
@@ -791,7 +791,7 @@
           }
         });
         
-        dialog.setSize("400px", "400px");
+        dialog.setSize("420px", "420px");
         dialog.open();
       }
       

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -778,7 +778,7 @@
                     subMeanGradeElement.update("");
                   } else {
                     var gradeName = results.gradeName;
-                    subMeanGradeElement.update(gradeName);
+                    subMeanGradeElement.update(getLocale().getText("students.viewStudent.subjectGrades.givenSubjectGradeLabel") + " " + gradeName);
                   }
                 },
                 onFailure: function(errorMessage, errorCode, isHttpError, jsonResponse) {
@@ -791,7 +791,7 @@
           }
         });
         
-        dialog.setSize("420px", "420px");
+        dialog.setSize("460px", "420px");
         dialog.open();
       }
       

--- a/pyramus/updates/116.001/230222_studentsubjectgrade_notnull.xml
+++ b/pyramus/updates/116.001/230222_studentsubjectgrade_notnull.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<update xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ofw.fi/xml/2011/java-xmldb-updater/UpdaterSchema.xsd">
+
+  <sql>alter table StudentSubjectGrade modify gradeApprover bigint not null;</sql>
+
+</update>


### PR DESCRIPTION
Added required classes to student subject grade dialog to inform the user that the fields are mandatory. Also made gradeApprover mandatory in the entity as it was essentially considered mandatory in backend.

Not ideal solution as observing the form validation process is not currently possible nor easy so the dialog Save button is still active even if the form is invalid. This will puke out an ugly backend exception if the fields are not filled.