### PR TITLE
JPA adjustments

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
@@ -382,8 +382,7 @@ public abstract class CourseBase implements ArchivableEntity {
   @IndexedEmbedded(includeEmbeddedObjectId = true) 
   private Set<Curriculum> curriculums = new HashSet<>();
 
-  @OneToMany
-  @JoinColumn (name = "course", updatable = false, insertable = false)
+  @OneToMany (mappedBy = "course", fetch = FetchType.LAZY)
   @IndexedEmbedded(includeEmbeddedObjectId = true)
   private List<CourseModule> courseModules = new Vector<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseModule.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseModule.java
@@ -3,7 +3,6 @@ package fi.otavanopisto.pyramus.domainmodel.base;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -82,7 +81,7 @@ public class CourseModule {
   @GeneratedValue(strategy = GenerationType.IDENTITY)  
   private Long id;
 
-  @ManyToOne (fetch = FetchType.LAZY)
+  @ManyToOne
   @JoinColumn(name="course", nullable = false)
   @NotNull
   private CourseBase course;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/Course.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/Course.java
@@ -329,7 +329,7 @@ public class Course extends CourseBase implements ArchivableEntity, ContextRefer
     this.courseTemplate = courseTemplate;
   }
 
-  @ManyToOne
+  @ManyToOne (fetch = FetchType.LAZY)
   @JoinColumn(name="module")
   private Module module;
   


### PR DESCRIPTION
* Fixes the warning spam `Narrowing proxy to class .. this operation breaks ==`.
  * This was due to lazy loading on `CourseModule.course` pointing to a superclass (`CourseBase`), for which Hibernate tries to create a proxy. The proxy has issues with equality and type of the (sub)classes, thus the error. This change results in more complicated queries though as the element is not lazily loaded anymore.
* Changed `CourseBase.courseModules` reverse mapping to be done by `@OneToMany.mappedBy` instead of `@JoinColumn`. Apparently it worked before but `mappedBy` seems to be the preferred method. `@JoinColumn` typically specifies a column in the table, which never existed here so the extra properties were useless too.
* Added lazy loading to `Course.module`. `Module` is rarely used through `Course` and it drops some extra tables from the queries that fetch `Course`s from database.
