### PR TITLE
Lisätty logitusta mitätöintiin

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiStudentHandler.java
@@ -270,6 +270,7 @@ public abstract class KoskiStudentHandler {
       }
     } else {
       // Student.archived=true -> mitätöity
+      logger.info(String.format("Invalidating an archived student %d as part of update.", student.getId()));
       tila.addOpiskeluoikeusJakso(new OpiskeluoikeusJakso(new Date(), OpiskeluoikeudenTila.mitatoity));
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/ArchiveStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/ArchiveStudentJSONRequestController.java
@@ -8,19 +8,25 @@ import fi.otavanopisto.pyramus.dao.DAOFactory;
 import fi.otavanopisto.pyramus.dao.application.ApplicationDAO;
 import fi.otavanopisto.pyramus.dao.projects.StudentProjectDAO;
 import fi.otavanopisto.pyramus.dao.students.StudentDAO;
+import fi.otavanopisto.pyramus.dao.users.StaffMemberDAO;
 import fi.otavanopisto.pyramus.domainmodel.application.Application;
 import fi.otavanopisto.pyramus.domainmodel.projects.StudentProject;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
+import fi.otavanopisto.pyramus.domainmodel.users.StaffMember;
 import fi.otavanopisto.pyramus.framework.JSONRequestController;
 import fi.otavanopisto.pyramus.framework.UserRole;
 
 public class ArchiveStudentJSONRequestController extends JSONRequestController {
   
   public void process(JSONRequestContext requestContext) {
+    StaffMemberDAO staffMemberDAO = DAOFactory.getInstance().getStaffMemberDAO();
     StudentDAO studentDAO = DAOFactory.getInstance().getStudentDAO();
+    
+    StaffMember loggedUser = staffMemberDAO.findById(requestContext.getLoggedUserId());
+    
     Long studentId = requestContext.getLong("student");
     Student student = studentDAO.findById(studentId);
-    studentDAO.archive(student);
+    studentDAO.archive(student, loggedUser);
     
     // Archive the student projects of archived student
     StudentProjectDAO studentProjectDAO = DAOFactory.getInstance().getStudentProjectDAO();


### PR DESCRIPTION
Lisätty logitieto mitätöinnistä kun se tapahtuu osana tietojen tallennusprosessia. Mitätöinnissä on mahdollisesti joku yhdenaikaisuusongelma tai muu vastaava kun itse ongelmaa ei saa mitenkään helposti toistettua. Välilehden poistaminen tuntuu mitätöivän sen ihan oikein testatessa.

Käytetty archive-metodi käytti GenericDAO:n archivea, kun StudentDAO:ssa on loggausta yms niin vaihdoin siihen, itse mitätöintiin sillä ei ollut vaikutusta.

Closes #1608 