### PR TITLE
Koski-integraation ehostuskierros, kevät 2025

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiConsts.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiConsts.java
@@ -41,6 +41,11 @@ public class KoskiConsts {
   public static class SchoolVariables {
     public static final String KOSKI_SCHOOL_OID = "koski.schooloid";
   }
+
+  public static class Perusopetus {
+    // Perusopetuksen uskonnon aineet. Elämänkatsomustieto (et) ei kuulu näihin, sille on oma lokeronsa.
+    public static final Set<String> USKONTO = Set.of("ue", "uo", "ui");
+  }
   
   public static class SubjectSelections {
     public static final String MATH = "lukioMatematiikka";

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiConsts.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiConsts.java
@@ -44,7 +44,10 @@ public class KoskiConsts {
 
   public static class Perusopetus {
     // Perusopetuksen uskonnon aineet. Elämänkatsomustieto (et) ei kuulu näihin, sille on oma lokeronsa.
-    public static final Set<String> USKONTO = Set.of("ue", "uo", "ui");
+    public static final Set<String> USKONTO       = Set.of("ue", "uo", "ui");
+    
+    // Perusopetuksen uskonnon ainevalinnat. Elämänkatsomustieto (et) kuuluu näihin ja nämä on keskenään poissulkevia.
+    public static final Set<String> USKONTO_JA_ET = Set.of("ue", "uo", "ui", "et");
   }
   
   public static class SubjectSelections {

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiController.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiController.java
@@ -205,7 +205,17 @@ public class KoskiController {
     markForUpdate(student.getPerson());
   }
   
-  private void markForUpdate(Person person) {
+  /**
+   * Marks given person to be added to the update queue.
+   * 
+   * @param person the person
+   */
+  public void markForUpdate(Person person) {
+    if (person == null) {
+      logger.severe("Null person passed to method.");
+      return;
+    }
+    
     try {
       if (settings.hasReportedStudents(person)) {
         List<KoskiPersonLog> entries = koskiPersonLogDAO.listByPerson(person);

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiStudentHandler.java
@@ -3,6 +3,7 @@ package fi.otavanopisto.pyramus.koski;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -958,4 +959,10 @@ public abstract class KoskiStudentHandler {
     return null;
   }
   
+  protected List<String> getSortedKeys(Map<String, ?> map) {
+    List<String> keys = new ArrayList<>(map.keySet());
+    Collections.sort(keys, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+    return keys;
+  }
+
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/StudentSubjectSelections.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/StudentSubjectSelections.java
@@ -137,6 +137,17 @@ public class StudentSubjectSelections {
     this.religion = religion;
   }
 
+  /**
+   * Returns true if the given subject is selected 
+   * as the religion subject by the student.
+   * 
+   * @param subjectCode subject's code
+   * @return true if given subject is selected as religion subject
+   */
+  public boolean isReligion(String subjectCode) {
+    return StringUtils.equals(getReligion(), subjectCode);
+  }
+  
   public String getAccomplishments() {
     return accomplishments;
   }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AikuistenPerusopetuksenOpiskeluoikeus.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AikuistenPerusopetuksenOpiskeluoikeus.java
@@ -1,7 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.aikuistenperusopetus;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -21,7 +21,7 @@ public class AikuistenPerusopetuksenOpiskeluoikeus extends Opiskeluoikeus {
     suoritukset.add(suoritus);
   }
   
-  public Set<AikuistenPerusopetuksenSuoritus> getSuoritukset() {
+  public List<AikuistenPerusopetuksenSuoritus> getSuoritukset() {
     return suoritukset;
   }
 
@@ -34,6 +34,6 @@ public class AikuistenPerusopetuksenOpiskeluoikeus extends Opiskeluoikeus {
     this.lisatiedot = lisatiedot;
   }
 
-  private final Set<AikuistenPerusopetuksenSuoritus> suoritukset = new HashSet<>();
+  private final List<AikuistenPerusopetuksenSuoritus> suoritukset = new ArrayList<>();
   private AikuistenPerusopetuksenOpiskeluoikeudenLisatiedot lisatiedot;
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AikuistenPerusopetuksenOppimaaranSuoritus.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AikuistenPerusopetuksenOppimaaranSuoritus.java
@@ -1,7 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.aikuistenperusopetus;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -30,7 +30,7 @@ public class AikuistenPerusopetuksenOppimaaranSuoritus extends AikuistenPerusope
     osasuoritukset.add(osasuoritus);
   }
   
-  public Set<AikuistenPerusopetuksenOsasuoritus> getOsasuoritukset() {
+  public List<AikuistenPerusopetuksenOsasuoritus> getOsasuoritukset() {
     return osasuoritukset;
   }
   
@@ -39,5 +39,5 @@ public class AikuistenPerusopetuksenOppimaaranSuoritus extends AikuistenPerusope
   }
   
   private final Koulutusmoduuli koulutusmoduuli = new Koulutusmoduuli(Koulutus.K201101);
-  private final Set<AikuistenPerusopetuksenOsasuoritus> osasuoritukset = new HashSet<>();
+  private final List<AikuistenPerusopetuksenOsasuoritus> osasuoritukset = new ArrayList<>();
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/KoskiAikuistenPerusopetuksenStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/KoskiAikuistenPerusopetuksenStudentHandler.java
@@ -184,15 +184,22 @@ public class KoskiAikuistenPerusopetuksenStudentHandler extends AbstractAikuiste
       subjectCode = "OPA";
     }
 
-    // Uskonto
-    if (KoskiConsts.Perusopetus.USKONTO.contains(subjectCode)) {
+    /*
+     * Uskonnon ainevalinta. Uskonnosta voi olla valittuna aina vain 
+     * yksi aine. Jos opiskelija opiskelee useampaa samaan aikaan,
+     * toissijainen hyväksiluetaan osaksi ensisijaista uskonnon ainetta.
+     */
+    if (KoskiConsts.Perusopetus.USKONTO_JA_ET.contains(subjectCode)) {
       // Vain ainevalinnoissa olevat uskonnon aineet ilmoitetaan
       if (!studentSubjects.isReligion(subjectCode)) {
         return null;
       }
       
-      // Uskonnon oppiaineille käytetään ainekoodia KT
-      subjectCode = "KT";
+      // Elämänkatsomustiedolla (et) on oma oppiaineensa, Muille
+      // uskonnon oppiaineille käytetään ainekoodia KT
+      if (KoskiConsts.Perusopetus.USKONTO.contains(subjectCode)) {
+        subjectCode = "KT";
+      }
     }
 
     if (map.containsKey(subjectCode)) {

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/APASuoritus.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/APASuoritus.java
@@ -1,7 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.apa;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -29,7 +29,7 @@ public class APASuoritus extends AikuistenPerusopetuksenSuoritus {
     osasuoritukset.add(osasuoritus);
   }
   
-  public Set<APAOppiaineenSuoritus> getOsasuoritukset() {
+  public List<APAOppiaineenSuoritus> getOsasuoritukset() {
     return osasuoritukset;
   }
   
@@ -38,5 +38,5 @@ public class APASuoritus extends AikuistenPerusopetuksenSuoritus {
   }
   
   private final APAKoulutusmoduuli koulutusmoduuli = new APAKoulutusmoduuli(SuorituksenTyyppi.aikuistenperusopetuksenoppimaaranalkuvaihe);
-  private final Set<APAOppiaineenSuoritus> osasuoritukset = new HashSet<>();
+  private final List<APAOppiaineenSuoritus> osasuoritukset = new ArrayList<>();
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/KoskiAPAStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/KoskiAPAStudentHandler.java
@@ -138,7 +138,10 @@ public class KoskiAPAStudentHandler extends AbstractAikuistenPerusopetuksenHandl
       }
     }
     
-    for (OppiaineenSuoritusWithSubject<APAOppiaineenSuoritus> oppiaineenSuoritusWSubject : map.values()) {
+    List<String> sortedSubjects = getSortedKeys(map);
+    for (String subjectCode : sortedSubjects) {
+      OppiaineenSuoritusWithSubject<APAOppiaineenSuoritus> oppiaineenSuoritusWSubject = map.get(subjectCode);
+      
       APAOppiaineenSuoritus oppiaineenSuoritus = oppiaineenSuoritusWSubject.getOppiaineenSuoritus();
       if (CollectionUtils.isEmpty(oppiaineenSuoritus.getOsasuoritukset())) {
         // Skip empty subjects

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/KoskiAPAStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/apa/KoskiAPAStudentHandler.java
@@ -247,7 +247,7 @@ public class KoskiAPAStudentHandler extends AbstractAikuistenPerusopetuksenHandl
       AikuistenPerusopetuksenAlkuvaiheenKurssit2017 kurssi = AikuistenPerusopetuksenAlkuvaiheenKurssit2017.valueOf(kurssiKoodi);
       tunniste = new APAKurssinTunnisteOPS2017(kurssi);
     } else {
-      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getSubject().getName()));
+      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getCourseName()));
       tunniste = new APAKurssinTunnistePaikallinen(paikallinenKoodi);
     }
       

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixLukioStudentHandler.java
@@ -186,7 +186,10 @@ public class KoskiInternetixLukioStudentHandler extends AbstractKoskiLukioStuden
       }
     }
     
-    for (OppiaineenSuoritusWithCurriculum<LukionOppiaineenSuoritus> lukionOppiaineenSuoritus : map.values()) {
+    List<String> sortedSubjects = getSortedKeys(map);
+    for (String subjectCode : sortedSubjects) {
+      OppiaineenSuoritusWithCurriculum<LukionOppiaineenSuoritus> lukionOppiaineenSuoritus = map.get(subjectCode);
+      
       if (CollectionUtils.isEmpty(lukionOppiaineenSuoritus.getOppiaineenSuoritus().getOsasuoritukset())) {
         // Skip empty subjects
         continue;

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixLukioStudentHandler.java
@@ -376,7 +376,7 @@ public class KoskiInternetixLukioStudentHandler extends AbstractKoskiLukioStuden
       LukionKurssinTyyppi kurssinTyyppi = findCourseType(student, courseCredit, true, LukionKurssinTyyppi.pakollinen, LukionKurssinTyyppi.syventava);
       tunniste = new LukionKurssinTunnisteValtakunnallinenOPS2004(kurssi, kurssinTyyppi);
     } else {
-      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getSubject().getName()));
+      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getCourseName()));
       LukionKurssinTyyppi kurssinTyyppi = findCourseType(student, courseCredit, true, LukionKurssinTyyppi.syventava, LukionKurssinTyyppi.soveltava);
       tunniste = new LukionKurssinTunnistePaikallinen(paikallinenKoodi , kurssinTyyppi, kuvaus(courseCredit.getCourseName()));
     }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixPkStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixPkStudentHandler.java
@@ -329,7 +329,7 @@ public class KoskiInternetixPkStudentHandler extends AbstractAikuistenPerusopetu
       AikuistenPerusopetuksenPaattovaiheenKurssit2017 kurssi = AikuistenPerusopetuksenPaattovaiheenKurssit2017.valueOf(kurssiKoodi);
       tunniste = new AikuistenPerusopetuksenKurssinTunnistePV2017(kurssi);
     } else {
-      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getSubject().getName()));
+      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getCourseName()));
       tunniste = new AikuistenPerusopetuksenKurssinTunnistePaikallinen(paikallinenKoodi);
     }
       

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixPkStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/internetix/KoskiInternetixPkStudentHandler.java
@@ -183,7 +183,10 @@ public class KoskiInternetixPkStudentHandler extends AbstractAikuistenPerusopetu
     
     PerusopetuksenSuoritusTapa perusopetuksenSuoritusTapa = suoritusTapa(student);
 
-    for (OppiaineenSuoritusWithCurriculum<AikuistenPerusopetuksenOppiaineenSuoritus> oppiaineenSuoritus : map.values()) {
+    List<String> sortedSubjects = getSortedKeys(map);
+    for (String subjectCode : sortedSubjects) {
+      OppiaineenSuoritusWithCurriculum<AikuistenPerusopetuksenOppiaineenSuoritus> oppiaineenSuoritus = map.get(subjectCode);
+      
       if (CollectionUtils.isEmpty(oppiaineenSuoritus.getOppiaineenSuoritus().getOsasuoritukset())) {
         // Skip empty subjects
         continue;

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/KoskiLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/KoskiLukioStudentHandler.java
@@ -317,7 +317,7 @@ public class KoskiLukioStudentHandler extends AbstractKoskiLukioStudentHandler {
       LukionKurssinTyyppi kurssinTyyppi = findCourseType(student, courseCredit, true, LukionKurssinTyyppi.pakollinen, LukionKurssinTyyppi.syventava);
       tunniste = new LukionKurssinTunnisteValtakunnallinenOPS2004(kurssi, kurssinTyyppi);
     } else {
-      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getSubject().getName()));
+      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getCourseName()));
       LukionKurssinTyyppi kurssinTyyppi = findCourseType(student, courseCredit, true, LukionKurssinTyyppi.syventava, LukionKurssinTyyppi.soveltava);
       tunniste = new LukionKurssinTunnistePaikallinen(paikallinenKoodi , kurssinTyyppi, kuvaus(courseCredit.getCourseName()));
     }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/KoskiLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/KoskiLukioStudentHandler.java
@@ -107,7 +107,7 @@ public class KoskiLukioStudentHandler extends AbstractKoskiLukioStudentHandler {
     OrganisaationToimipiste toimipiste = new OrganisaationToimipisteOID(departmentIdentifier);
     EducationType studentEducationType = student.getStudyProgramme() != null && student.getStudyProgramme().getCategory() != null ? 
         student.getStudyProgramme().getCategory().getEducationType() : null;
-    Set<LukionOppiaineenSuoritus> oppiaineet = assessmentsToModel(handler, ops, student, studentEducationType, studentSubjects, laskeKeskiarvot);
+    List<LukionOppiaineenSuoritus> oppiaineet = assessmentsToModel(handler, ops, student, studentEducationType, studentSubjects, laskeKeskiarvot);
 
     LukionOppimaaranSuoritus suoritus = new LukionOppimaaranSuoritus(
         LukionOppimaara.aikuistenops, Kieli.FI, toimipiste);
@@ -131,9 +131,9 @@ public class KoskiLukioStudentHandler extends AbstractKoskiLukioStudentHandler {
     return studentSubjects;
   }
 
-  private Set<LukionOppiaineenSuoritus> assessmentsToModel(KoskiStudyProgrammeHandler handler, OpiskelijanOPS ops, Student student, EducationType studentEducationType, StudentSubjectSelections studentSubjects, boolean calculateMeanGrades) {
+  private List<LukionOppiaineenSuoritus> assessmentsToModel(KoskiStudyProgrammeHandler handler, OpiskelijanOPS ops, Student student, EducationType studentEducationType, StudentSubjectSelections studentSubjects, boolean calculateMeanGrades) {
     Collection<CreditStub> credits = listCredits(student, true, true, ops, credit -> matchingCurriculumFilter(student, credit));
-    Set<LukionOppiaineenSuoritus> results = new HashSet<>();
+    List<LukionOppiaineenSuoritus> results = new ArrayList<>();
     
     Map<String, OppiaineenSuoritusWithSubject<LukionOppiaineenSuoritus>> map = new HashMap<>();
     Set<OppiaineenSuoritusWithSubject<LukionOppiaineenSuoritus>> accomplished = new HashSet<>();
@@ -153,7 +153,10 @@ public class KoskiLukioStudentHandler extends AbstractKoskiLukioStudentHandler {
       }
     }
     
-    for (OppiaineenSuoritusWithSubject<LukionOppiaineenSuoritus> lukionOppiaineenSuoritusWSubject : map.values()) {
+    List<String> sortedSubjects = getSortedKeys(map);
+    for (String subjectCode : sortedSubjects) {
+      OppiaineenSuoritusWithSubject<LukionOppiaineenSuoritus> lukionOppiaineenSuoritusWSubject = map.get(subjectCode);
+      
       LukionOppiaineenSuoritus lukionOppiaineenSuoritus = lukionOppiaineenSuoritusWSubject.getOppiaineenSuoritus();
       if (CollectionUtils.isEmpty(lukionOppiaineenSuoritus.getOsasuoritukset())) {
         // Skip empty subjects

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/LukionOppimaaranSuoritus.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/LukionOppimaaranSuoritus.java
@@ -1,7 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.lukio;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,7 +34,7 @@ public class LukionOppimaaranSuoritus extends LukionSuoritus {
     osasuoritukset.add(osasuoritus);
   }
   
-  public Set<LukionOsasuoritus> getOsasuoritukset() {
+  public List<LukionOsasuoritus> getOsasuoritukset() {
     return osasuoritukset;
   }
   
@@ -49,5 +49,5 @@ public class LukionOppimaaranSuoritus extends LukionSuoritus {
   
   private final Koulutusmoduuli koulutusmoduuli = new Koulutusmoduuli(Koulutus.K309902);
   private final KoodistoViite<LukionOppimaara> oppimaara = new KoodistoViite<>();
-  private final Set<LukionOsasuoritus> osasuoritukset = new HashSet<>();
+  private final List<LukionOsasuoritus> osasuoritukset = new ArrayList<>();
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/AbstractKoskiLukioStudentHandler2019.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/AbstractKoskiLukioStudentHandler2019.java
@@ -77,9 +77,9 @@ public abstract class AbstractKoskiLukioStudentHandler2019 extends AbstractKoski
     return studentSubjects;
   }
 
-  protected Set<LukionOsasuoritus2019> assessmentsToModel(OpiskelijanOPS ops, Student student, EducationType studentEducationType, StudentSubjectSelections studentSubjects, boolean calculateMeanGrades) {
+  protected List<LukionOsasuoritus2019> assessmentsToModel(OpiskelijanOPS ops, Student student, EducationType studentEducationType, StudentSubjectSelections studentSubjects, boolean calculateMeanGrades) {
     Collection<CreditStub> credits = listCredits(student, true, true, ops, credit -> matchingCurriculumFilter(student, credit));
-    Set<LukionOsasuoritus2019> results = new HashSet<>();
+    List<LukionOsasuoritus2019> results = new ArrayList<>();
     
     Map<String, OppiaineenSuoritusWithSubject<LukionOsasuoritus2019>> map = new HashMap<>();
     Set<OppiaineenSuoritusWithSubject<LukionOsasuoritus2019>> accomplished = new HashSet<>();
@@ -99,7 +99,10 @@ public abstract class AbstractKoskiLukioStudentHandler2019 extends AbstractKoski
       }
     }
     
-    for (OppiaineenSuoritusWithSubject<LukionOsasuoritus2019> lukionOppiaineenSuoritusWSubject : map.values()) {
+    List<String> sortedSubjects = getSortedKeys(map);
+    for (String subjectCode : sortedSubjects) {
+      OppiaineenSuoritusWithSubject<LukionOsasuoritus2019> lukionOppiaineenSuoritusWSubject = map.get(subjectCode);
+      
       LukionOsasuoritus2019 lukionOsaSuoritus = lukionOppiaineenSuoritusWSubject.getOppiaineenSuoritus();
       if (CollectionUtils.isEmpty(lukionOsaSuoritus.getOsasuoritukset())) {
         // Skip empty subjects

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/AbstractKoskiLukioStudentHandler2019.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/AbstractKoskiLukioStudentHandler2019.java
@@ -337,7 +337,7 @@ public abstract class AbstractKoskiLukioStudentHandler2019 extends AbstractKoski
       boolean pakollinen = kurssinTyyppi == LukionKurssinTyyppi.pakollinen;
 
       suorituksenTyyppi = SuorituksenTyyppi.lukionpaikallinenopintojakso;
-      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getSubject().getName()));
+      PaikallinenKoodi paikallinenKoodi = new PaikallinenKoodi(kurssiKoodi, kuvaus(courseCredit.getCourseName()));
       tunniste = new LukionOpintojaksonTunnistePaikallinen2019(paikallinenKoodi, laajuus, pakollinen, kuvaus(courseCredit.getCourseName()));
     }
       

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/KoskiInternetixLukioStudentHandler2019.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/KoskiInternetixLukioStudentHandler2019.java
@@ -1,6 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.lukio.ops2019;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -74,7 +75,7 @@ public class KoskiInternetixLukioStudentHandler2019 extends AbstractKoskiLukioSt
     EducationType studentEducationType = student.getStudyProgramme() != null && student.getStudyProgramme().getCategory() != null ? 
         student.getStudyProgramme().getCategory().getEducationType() : null;
     
-    Set<LukionOsasuoritus2019> oppiaineet = assessmentsToModel(ops, student, studentEducationType, studentSubjects, laskeKeskiarvot);
+    List<LukionOsasuoritus2019> oppiaineet = assessmentsToModel(ops, student, studentEducationType, studentSubjects, laskeKeskiarvot);
 
     LukionOppiaineenOppimaaranSuoritus2019 suoritus = new LukionOppiaineenOppimaaranSuoritus2019(
         LukionOppimaara.aikuistenops, Kieli.FI, toimipiste, getDiaarinumero(student));

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/KoskiLukioStudentHandler2019.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/KoskiLukioStudentHandler2019.java
@@ -99,7 +99,7 @@ public class KoskiLukioStudentHandler2019 extends AbstractKoskiLukioStudentHandl
     
     // NON-COMMON
     
-    Set<LukionOsasuoritus2019> oppiaineet = assessmentsToModel(ops, student, studentEducationType, studentSubjects, laskeKeskiarvot);
+    List<LukionOsasuoritus2019> oppiaineet = assessmentsToModel(ops, student, studentEducationType, studentSubjects, laskeKeskiarvot);
 
     LukionOppimaaranSuoritus2019 suoritus = new LukionOppimaaranSuoritus2019(
         LukionOppimaara.aikuistenops, Kieli.FI, toimipiste);

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/LukionOppiaineenOppimaaranSuoritus2019.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/LukionOppiaineenOppimaaranSuoritus2019.java
@@ -1,7 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.lukio.ops2019;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -26,7 +26,7 @@ public class LukionOppiaineenOppimaaranSuoritus2019 extends LukionSuoritus2019 {
     osasuoritukset.add(osasuoritus);
   }
   
-  public Set<LukionOppiaineenSuoritus2019> getOsasuoritukset() {
+  public List<LukionOppiaineenSuoritus2019> getOsasuoritukset() {
     return osasuoritukset;
   }
 
@@ -35,5 +35,5 @@ public class LukionOppiaineenOppimaaranSuoritus2019 extends LukionSuoritus2019 {
   }
 
   private final LukionOppiaineenOppimaaranKoulutusmoduuli2019 koulutusmoduuli = new LukionOppiaineenOppimaaranKoulutusmoduuli2019();
-  private final Set<LukionOppiaineenSuoritus2019> osasuoritukset = new HashSet<>();
+  private final List<LukionOppiaineenSuoritus2019> osasuoritukset = new ArrayList<>();
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/LukionOppimaaranSuoritus2019.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/ops2019/LukionOppimaaranSuoritus2019.java
@@ -1,7 +1,7 @@
 package fi.otavanopisto.pyramus.koski.model.lukio.ops2019;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -30,7 +30,7 @@ public class LukionOppimaaranSuoritus2019 extends LukionSuoritus2019 {
     osasuoritukset.add(osasuoritus);
   }
   
-  public Set<LukionOsasuoritus2019> getOsasuoritukset() {
+  public List<LukionOsasuoritus2019> getOsasuoritukset() {
     return osasuoritukset;
   }
   
@@ -39,5 +39,5 @@ public class LukionOppimaaranSuoritus2019 extends LukionSuoritus2019 {
   }
 
   private final Koulutusmoduuli koulutusmoduuli = new Koulutusmoduuli(Koulutus.K309902);
-  private final Set<LukionOsasuoritus2019> osasuoritukset = new HashSet<>();
+  private final List<LukionOsasuoritus2019> osasuoritukset = new ArrayList<>();
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/CourseAssessmentDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/CourseAssessmentDAO.java
@@ -93,6 +93,23 @@ public class CourseAssessmentDAO extends PyramusEntityDAO<CourseAssessment> {
     return entityManager.createQuery(criteria).getResultList();
   }  
   
+  public List<CourseAssessment> listByCourseModule(CourseModule courseModule, TSB archived) {
+    EntityManager entityManager = getEntityManager(); 
+    
+    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<CourseAssessment> criteria = criteriaBuilder.createQuery(CourseAssessment.class);
+    Root<CourseAssessment> root = criteria.from(CourseAssessment.class);
+    
+    Predicates predicates = Predicates.newInstance()
+        .add(criteriaBuilder.equal(root.get(CourseAssessment_.courseModule), courseModule))
+        .add(criteriaBuilder.equal(root.get(CourseAssessment_.archived), archived.booleanValue()), archived.isBoolean());
+    
+    criteria.select(root);
+    criteria.where(criteriaBuilder.and(predicates.array()));
+    
+    return entityManager.createQuery(criteria).getResultList();
+  }  
+  
   /**
    * Lists all student's course assessments excluding archived ones
    * 

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
@@ -124,6 +124,8 @@ generic.errors.missingValue = The value {0} is missing from {1}. Please contact 
 
 generic.errors.duplicateCourseStudent = Student {0} cannot be added or modified because he/she is already a member of the course.
 generic.errors.cannotAddStudentsToCourseTemplate = Cannot add students to Course Template
+generic.errors.courseStudentNotFound = Couldn't find specified Course Student
+generic.errors.cannotDeleteCourseModuleWithAssessments = Cannot delete Course Module that has Assessments
 
 generic.draft.confirmDraftRestoreDialogTitle = View draft
 generic.draft.confirmDraftRestoreDialogContent = Do you want to restore view''s data from draft saved at {0} ?   

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
@@ -124,6 +124,8 @@ generic.errors.missingValue = Arvo {0} puuttuu entiteetistä {1}. Ota yhteys kehi
 
 generic.errors.duplicateCourseStudent = Opiskelijaa {0} ei voida lisätä/muokata, koska hän on jo kurssilla.
 generic.errors.cannotAddStudentsToCourseTemplate = Kurssiaihioon ei voi lisätä opiskelijoita
+generic.errors.courseStudentNotFound = Kurssin opiskelijaa ei löytynyt
+generic.errors.cannotDeleteCourseModuleWithAssessments = Kurssin modulia ei voi poistaa, koska siitä on arviointeja
 
 generic.draft.confirmDraftRestoreDialogTitle = N\u00E4kym\u00E4n luonnos 
 generic.draft.confirmDraftRestoreDialogContent = Haluatko, ett\u00E4 n\u00E4kym\u00E4n tiedot palautetaan {0} tallennetusta luonnoksesta ?  

--- a/pyramus/src/main/webapp/templates/students/editstudentkoskidialog.jsp
+++ b/pyramus/src/main/webapp/templates/students/editstudentkoskidialog.jsp
@@ -20,6 +20,14 @@
     <jsp:include page="/templates/generic/glasspane_support.jsp"></jsp:include>
     
     <script type="text/javascript">
+      function getResults() {
+        return {
+          saved: __wasSaved
+        };
+      }
+
+      var __wasSaved = false;
+      
       /**
        * Called when this dialog loads. Initializes the search navigation and student tables.
        *
@@ -224,6 +232,7 @@
             formElement._globalGlassPane.hide();
             delete formElement._globalGlassPane;
             formElement._globalGlassPane = undefined;
+            __wasSaved = true;
           },
           onFailure: function (errorMessage, errorCode, isHttpError, jsonResponse) {
             alert(errorMessage);
@@ -233,7 +242,6 @@
           }
         });
       }
-
     </script>
 
   </head>

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -1967,15 +1967,19 @@
           id : 'editStudentKoskiDialog',
           contentURL : GLOBAL_contextPath + '/students/editstudentkoskidialog.page?personId=' + personId,
           centered : true,
-          showCancel : true,
+          showOk : true,
+          showCancel : false,
           title : '<fmt:message key="students.editStudentKoskiDialog.dialogTitle"/>',
-          cancelLabel : '<fmt:message key="students.editStudentKoskiDialog.closeLabel"/>' 
+          okLabel : '<fmt:message key="students.editStudentKoskiDialog.closeLabel"/>' 
         });
         
         dialog.setSize("640px", "450px");
         dialog.addDialogListener(function(event) {
           switch (event.name) {
-            case 'cancelClick':
+            case 'okClick':
+              if (event.results.saved) {
+                window.location.reload(true);
+              }
             break;
           }
         });


### PR DESCRIPTION
* Opiskelijatieto-näkymän refresh, jos opiskelijan OID:ta muokataan Koski-dialogista
* Opiskelijan merkitseminen Koski-päivitysjonoon, kun
  - sen OID:ta muokataan opiskelijan tiedot -> Koski-dialogista
  - kurssin muokkauksessa opiskelijan linja vaihdetaan toiseksi (jos tästä on suoritus)
  - kurssin modulin kurssikoodi tai pituus muuttuu (opiskelijoille, joilla on suoritus)
* Paikallisille oppiaineille käytetään kurssin nimeä kurssin kuvauksessa (aiemmin vain kurssikoodi)
* Korjattu perusopetuksen et-aineen ilmoitustapa, oli virheellisesti ilmoitettu KT-aineena
* Oppiaineet järjestetty ainekoodin mukaiseen aakkosjärjestykseen Koskelle menevään jsoniin (aiheutti sen, että aineet oli aina sekalaisessa järjestyksessä Kosken käyttöliittymässä)

Closes #1648 
Closes #1507 
