### PR TITLE
Korjattu päivämäärien poistaminen opiskelijan tiedoista

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/framework/DateUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/framework/DateUtils.java
@@ -9,6 +9,32 @@ import java.util.Date;
 
 public class DateUtils {
 
+  /**
+   * Returns true if the date part of the two given dates are different.
+   * 
+   * If both are null, there's no change -> returns false.
+   * If one of the dates is null returns true.
+   * Else compares the date portion of the Dates
+   * 
+   * @param d1 date 1
+   * @param d2 date 2
+   * @return true if the date part is different between the two dates
+   */
+  public static boolean dateChanged(Date d1, Date d2) {
+    // Both null -> not changed (false)
+    if (d1 == null && d2 == null) {
+      return false;
+    }
+
+    // Other one is null, but because both weren't null, something changed (true)
+    if (d1 == null || d2 == null) {
+      return true;
+    }
+    
+    // isSameDay wants non-null dates which they should be at this point
+    return !org.apache.commons.lang3.time.DateUtils.isSameDay(d1, d2);
+  }
+
   public static Date setTime(Date date, int hours, int minutes, int seconds) {
     if (date == null) {
       return null;

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/json/students/EditStudentJSONRequestController.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.hibernate.StaleObjectStateException;
 
 import fi.internetix.smvc.SmvcRuntimeException;
@@ -74,6 +73,7 @@ import fi.otavanopisto.pyramus.domainmodel.users.InternalAuth;
 import fi.otavanopisto.pyramus.domainmodel.users.StaffMember;
 import fi.otavanopisto.pyramus.domainmodel.users.User;
 import fi.otavanopisto.pyramus.domainmodel.users.UserIdentification;
+import fi.otavanopisto.pyramus.framework.DateUtils;
 import fi.otavanopisto.pyramus.framework.JSONRequestController2;
 import fi.otavanopisto.pyramus.framework.PyramusRequestControllerAccess;
 import fi.otavanopisto.pyramus.framework.PyramusStatusCode;
@@ -294,9 +294,9 @@ public class EditStudentJSONRequestController extends JSONRequestController2 {
       Boolean active = requestContext.getBoolean("active." + student.getId());
       StudentCardType studentCardType = (StudentCardType) requestContext.getEnum("studentCardType." + student.getId(), StudentCardType.class);
       StudentCard studentCard = studentCardDAO.findByStudent(student);
-      boolean cardExpiryChanged = studentCard != null && dateChanged(studentCard.getExpiryDate(), studentCardExpires);
-      boolean studyEndDateChanged = dateChanged(student.getStudyEndDate(), studyEndDate);
-      boolean studyTimeEndChanged = dateChanged(student.getStudyTimeEnd(), studyTimeEnd);
+      boolean cardExpiryChanged = studentCard != null && DateUtils.dateChanged(studentCard.getExpiryDate(), studentCardExpires);
+      boolean studyEndDateChanged = DateUtils.dateChanged(student.getStudyEndDate(), studyEndDate);
+      boolean studyTimeEndChanged = DateUtils.dateChanged(student.getStudyTimeEnd(), studyTimeEnd);
       
       // Tags
 
@@ -587,8 +587,4 @@ public class EditStudentJSONRequestController extends JSONRequestController2 {
     requestContext.setRedirectURL(requestContext.getReferer(true));
   }
   
-  private boolean dateChanged(Date d1, Date d2) {
-    return d1 == null ? d2 == null ? false : true : !DateUtils.isSameDay(d1, d2);
-  }
-
 }


### PR DESCRIPTION
Apachen DateUtils antoi NPE:n, jos jompikumpi päivämääristä oli null. Vanha käsittely päästi `d2`-muuttujan null-arvolla läpi, joka tapahtui, jos esim aiemmin tallennetun opintojen päättymispäivän yritti poistaa opiskelijalta. Muokattu tsekkiä niin, ettei Apached DateUtilsiin päätyisi null-arvoja.

Ehkä syytä tsekata ettei vaikuta korttilogiikoihin.

Closes #1652 