### PR TITLE
Entity annotation fixes

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/application/Application.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/application/Application.java
@@ -2,6 +2,7 @@ package fi.otavanopisto.pyramus.domainmodel.application;
 
 import java.util.Date;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -242,7 +243,7 @@ public class Application implements ArchivableEntity {
   
   @Lob
   @NotNull
-  @Column (nullable=false)
+  @Basic(optional = false)
   @Field
   private String formData;
   

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/application/ApplicationLog.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/application/ApplicationLog.java
@@ -2,6 +2,7 @@ package fi.otavanopisto.pyramus.domainmodel.application;
 
 import java.util.Date;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -95,7 +96,7 @@ public class ApplicationLog implements ArchivableEntity {
 
   @Lob
   @NotNull
-  @Column (nullable=false)
+  @Basic(optional = false)
   private String text;
 
   @ManyToOne  

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/application/ApplicationMailTemplate.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/application/ApplicationMailTemplate.java
@@ -1,5 +1,6 @@
 package fi.otavanopisto.pyramus.domainmodel.application;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -90,7 +91,7 @@ public class ApplicationMailTemplate implements ArchivableEntity {
 
   @Lob
   @NotNull
-  @Column (nullable=false)
+  @Basic(optional = false)
   private String content;
 
   @ManyToOne  

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/ComponentBase.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/ComponentBase.java
@@ -84,7 +84,6 @@ public abstract class ComponentBase implements ArchivableEntity {
 
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column 
   @Field
   private String description;
   

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/ContactInfo.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/ContactInfo.java
@@ -167,7 +167,6 @@ public class ContactInfo {
 
   @Lob  
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String additionalInfo;
  
   @Version

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/CourseBase.java
@@ -352,7 +352,6 @@ public abstract class CourseBase implements ArchivableEntity {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   @Field
   private String description;
   

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/base/Person.java
@@ -1071,7 +1071,6 @@ public class Person implements ContextReference {
 
   @Lob
   @Basic(fetch = FetchType.LAZY)
-  @Column
   private String basicInfo;
 
   @OneToMany

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/changelog/ChangeLogEntryProperty.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/changelog/ChangeLogEntryProperty.java
@@ -1,7 +1,6 @@
 package fi.otavanopisto.pyramus.domainmodel.changelog;
 
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -57,6 +56,5 @@ public class ChangeLogEntryProperty {
   private ChangeLogEntry entry;
   
   @Lob
-  @Column
   private String value;
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/CourseStudentVariable.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/courses/CourseStudentVariable.java
@@ -1,5 +1,6 @@
 package fi.otavanopisto.pyramus.domainmodel.courses;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -74,8 +75,8 @@ public class CourseStudentVariable {
   @JoinColumn(name = "variableKey")
   private CourseStudentVariableKey key;
   
+  @Basic(optional = false)
   @NotEmpty
-  @Column (nullable = false)
   @NotNull
   @Lob
   private String value;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/drafts/FormDraft.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/drafts/FormDraft.java
@@ -83,7 +83,6 @@ public class FormDraft {
   private String url;
   
   @Lob
-  @Column
   private String data;
   
   @ManyToOne  

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/file/File.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/file/File.java
@@ -147,7 +147,6 @@ public class File implements ArchivableEntity, ModificationTrackedEntity {
   private String contentType;
   
   @Lob
-  @Column
   private byte[] data;
   
   @NotNull

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseAssessmentRequest.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseAssessmentRequest.java
@@ -93,7 +93,6 @@ public class CourseAssessmentRequest implements ArchivableEntity {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String requestText;
 
   @NotNull

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/Credit.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/Credit.java
@@ -113,7 +113,6 @@ public class Credit implements ArchivableEntity {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String verbalAssessment;
   
   @ManyToOne  

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CreditVariable.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CreditVariable.java
@@ -1,5 +1,6 @@
 package fi.otavanopisto.pyramus.domainmodel.grading;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -74,8 +75,8 @@ public class CreditVariable {
   @JoinColumn(name = "variableKey")
   private CreditVariableKey key;
   
+  @Basic(optional = false)
   @NotEmpty
-  @Column (nullable = false)
   @NotNull
   @Lob
   private String value;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/GradingScale.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/GradingScale.java
@@ -94,7 +94,6 @@ public class GradingScale implements ArchivableEntity {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String description;
   
   private Boolean archived = Boolean.FALSE;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/SpokenLanguageExam.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/SpokenLanguageExam.java
@@ -91,7 +91,6 @@ public class SpokenLanguageExam {
 
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column (nullable = true)
   private String verbalAssessment;
   
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpPageContent.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/help/HelpPageContent.java
@@ -3,6 +3,7 @@ package fi.otavanopisto.pyramus.domainmodel.help;
 import java.util.Date;
 import java.util.Locale;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -107,7 +108,7 @@ public class HelpPageContent {
   private Locale locale;
   
   @Lob
-  @Column (nullable=false)
+  @Basic(optional = false)
   @NotNull
   @NotEmpty  
   @Field

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/koski/KoskiPersonLog.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/koski/KoskiPersonLog.java
@@ -87,7 +87,6 @@ public class KoskiPersonLog {
   private KoskiPersonState state;
   
   @Lob
-  @Column
   private String message;
   
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/matriculation/MatriculationExamEnrollment.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/matriculation/MatriculationExamEnrollment.java
@@ -224,12 +224,10 @@ public class MatriculationExamEnrollment {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String contactInfoChange;
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String message;
   
   @Column(nullable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/Project.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/Project.java
@@ -299,7 +299,6 @@ public class Project implements ArchivableEntity {
 
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   @Field
   private String description;
 

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/StudentProject.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/projects/StudentProject.java
@@ -337,7 +337,6 @@ public class StudentProject implements ArchivableEntity {
 
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   @Field
   private String description;
 

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/reports/Report.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/reports/Report.java
@@ -2,6 +2,7 @@ package fi.otavanopisto.pyramus.domainmodel.reports;
 
 import java.util.Date;
 
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -131,7 +132,7 @@ public class Report implements ArchivableEntity{
   private String name;
 
   @Lob
-  @Column (nullable = false)
+  @Basic(optional = false)
   @NotEmpty
   private String data;
   

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/Student.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/Student.java
@@ -4,7 +4,6 @@ import java.util.Date;
 import java.util.Set;
 
 import javax.persistence.Basic;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -317,7 +316,6 @@ public class Student extends User implements ArchivableEntity {
     
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String additionalInfo;
   
   @ManyToOne (fetch = FetchType.LAZY)
@@ -388,7 +386,6 @@ public class Student extends User implements ArchivableEntity {
 
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column (nullable = true)
   private String parentBillingDetails;
   
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentContactLogEntry.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentContactLogEntry.java
@@ -184,7 +184,6 @@ public class StudentContactLogEntry implements ArchivableEntity {
   private Student student;
   
   @Lob
-  @Column
   private String text;
   
   @Column (updatable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentContactLogEntryComment.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentContactLogEntryComment.java
@@ -153,7 +153,6 @@ public class StudentContactLogEntryComment implements ArchivableEntity {
   private StudentContactLogEntry entry;
   
   @Lob
-  @Column
   private String text;
   
   @Column (updatable = false)

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroup.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroup.java
@@ -257,7 +257,6 @@ public class StudentGroup implements ContextReference, ArchivableEntity {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String description;
   
   @Column

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroupContactLogEntry.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroupContactLogEntry.java
@@ -153,7 +153,6 @@ public class StudentGroupContactLogEntry implements ArchivableEntity {
   private StudentGroup studentGroup;
   
   @Lob
-  @Column
   private String text;
   
   private String creatorName;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroupContactLogEntryComment.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentGroupContactLogEntryComment.java
@@ -132,7 +132,6 @@ public class StudentGroupContactLogEntryComment implements ArchivableEntity {
   private StudentGroupContactLogEntry entry;
   
   @Lob
-  @Column
   private String text;
   
   private String creatorName;

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentImage.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentImage.java
@@ -1,6 +1,5 @@
 package fi.otavanopisto.pyramus.domainmodel.students;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -58,6 +57,5 @@ public class StudentImage {
   private String contentType;
   
   @Lob
-  @Column
   private byte[] data;
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentSubjectGrade.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentSubjectGrade.java
@@ -3,7 +3,6 @@ package fi.otavanopisto.pyramus.domainmodel.students;
 import java.util.Date;
 
 import javax.persistence.Basic;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -111,6 +110,5 @@ public class StudentSubjectGrade {
 
   @Lob
   @Basic(fetch = FetchType.LAZY)
-  @Column
   private String explanation;
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/EmailSignature.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/EmailSignature.java
@@ -1,6 +1,5 @@
 package fi.otavanopisto.pyramus.domainmodel.users;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -43,7 +42,6 @@ public class EmailSignature {
   private User user;
 
   @Lob
-  @Column
   private String signature;
 
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/StaffMember.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/StaffMember.java
@@ -22,8 +22,6 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.Store;
@@ -34,7 +32,6 @@ import fi.otavanopisto.pyramus.domainmodel.base.StudyProgramme;
 
 @Entity
 @Indexed
-@Cache (usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 @PrimaryKeyJoinColumn(name="id")
 public class StaffMember extends User implements ArchivableEntity {
   

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/StudentParent.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/users/StudentParent.java
@@ -13,14 +13,11 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import fi.otavanopisto.pyramus.domainmodel.base.Organization;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
 
 @Entity
-@Cache (usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 @PrimaryKeyJoinColumn(name="id")
 public class StudentParent extends User {
 

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/worklist/WorklistBillingSettings.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/worklist/WorklistBillingSettings.java
@@ -1,7 +1,6 @@
 package fi.otavanopisto.pyramus.domainmodel.worklist;
 
 import javax.persistence.Basic;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -30,7 +29,6 @@ public class WorklistBillingSettings {
   
   @Lob
   @Basic (fetch = FetchType.LAZY)
-  @Column
   private String settings;
 
 }


### PR DESCRIPTION
1. Removed `@Column`-annotations from `@Lob`-fields
  - Future Hibernate (6 onwards) considers fields with both of these as `tinytext` instead of `longtext`, because the `@Column` annotation defaults to 255 characters. This leads to issues with schema validation on startup. Removing the `@Column` annotation from `@Lob` fields fixes this. Links below have another option, if using `@Column` is unavoidable.
  - For `@Lob` fields which shouldn't be nullable, instead of `@Column(nullable = false)` use `@Basic(optional = false)`. This is functionally bit different, but still produces the `non null` in DDL. More info in the first link below.
  - The produced DDL with current Hibernate version seems intact with these changes
  - More info:
  - https://docs.jboss.org/hibernate/orm/6.5/introduction/html_single/Hibernate_Introduction.html#basic-attributes
  - https://hibernate.atlassian.net/browse/HHH-18295
  - https://hibernate.atlassian.net/browse/HHH-16094
2. Removed `@Cache` annotations from two subclasses. These should be only on the root level entity and were already throwing warnings at startup but completely stop working with later Hibernate versions.