### PR TITLE
YO-ilmoittautumisen muutoksia + muita fiksejä

### DIFF
--- a/common/src/main/java/fi/otavanopisto/pyramus/matriculation/MatriculationExamEnrollmentState.java
+++ b/common/src/main/java/fi/otavanopisto/pyramus/matriculation/MatriculationExamEnrollmentState.java
@@ -1,10 +1,24 @@
 package fi.otavanopisto.pyramus.matriculation;
 
+import java.util.Collections;
+import java.util.Set;
+
 public enum MatriculationExamEnrollmentState {
+  // Form has been saved by the student and is pending review
   PENDING,
+  // Guider has requested supplementation
   SUPPLEMENTATION_REQUEST,
+  // Student has supplemented the form
   SUPPLEMENTED,
+  // Form has been approved by the guider
   APPROVED,
+  // Form has been rejected by the guider
   REJECTED,
-  CONFIRMED;
+  // Form has been confirmed by the student
+  CONFIRMED,
+  // Form has been filled on behalf of the student
+  FILLED_ON_BEHALF;
+
+  // Terminal states
+  public static final Set<MatriculationExamEnrollmentState> TERMINAL_STATES = Collections.unmodifiableSet(Set.of(REJECTED, CONFIRMED, FILLED_ON_BEHALF));
 }

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiClient.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/KoskiClient.java
@@ -185,8 +185,7 @@ public class KoskiClient {
             // Having multiple periods is going to cause problems invalidating due to date checks in Koski
             opiskeluoikeus.getTila().getOpiskeluoikeusjaksot().clear();
             
-            Date invalidationDate = opiskeluoikeus.getPaattymispaiva() != null ? opiskeluoikeus.getPaattymispaiva() : 
-              opiskeluoikeus.getAlkamispaiva() != null ? opiskeluoikeus.getAlkamispaiva() : new Date();
+            Date invalidationDate = new Date();
             opiskeluoikeus.getTila().addOpiskeluoikeusJakso(
                 new OpiskeluoikeusJakso(invalidationDate, OpiskeluoikeudenTila.mitatoity));
           } else {

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/matriculation/MatriculationExamEnrollment.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/matriculation/MatriculationExamEnrollment.java
@@ -50,14 +50,6 @@ public class MatriculationExamEnrollment {
     this.nationalStudentNumber = nationalStudentNumber;
   }
 
-  public String getGuider() {
-    return guider;
-  }
-
-  public void setGuider(String guider) {
-    this.guider = guider;
-  }
-
   public int getNumMandatoryCourses() {
     return numMandatoryCourses;
   }
@@ -201,9 +193,6 @@ public class MatriculationExamEnrollment {
   
   @Column
   private Long nationalStudentNumber;
-  
-  @Column
-  private String guider;
   
   @Column
   @Enumerated(EnumType.STRING)

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale.properties
@@ -615,3 +615,4 @@ generic.matriculation.enrollmentStates.SUPPLEMENTED = Supplemented
 generic.matriculation.enrollmentStates.APPROVED = Approved
 generic.matriculation.enrollmentStates.REJECTED = Rejected
 generic.matriculation.enrollmentStates.CONFIRMED = Confirmed
+generic.matriculation.enrollmentStates.FILLED_ON_BEHALF = Filled on behalf

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale_fi_FI.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/javascriptlocale_fi_FI.properties
@@ -615,3 +615,4 @@ generic.matriculation.enrollmentStates.SUPPLEMENTED = Täydennetty
 generic.matriculation.enrollmentStates.APPROVED = Hyväksytty
 generic.matriculation.enrollmentStates.REJECTED = Peruttu
 generic.matriculation.enrollmentStates.CONFIRMED = Vahvistettu
+generic.matriculation.enrollmentStates.FILLED_ON_BEHALF = Täytetty opiskelijan puolesta

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
@@ -192,12 +192,6 @@ terms.search = Search
 terms.ok = OK
 terms.cancel = Cancel
 terms.save = Save
-terms.pending = Pending
-terms.approved = Approved
-terms.rejected = Rejected
-terms.supplementationRequest = Supplementation Request
-terms.supplemented = Supplemented
-terms.confirmed = Confirmed
  
 # Index
 
@@ -1888,6 +1882,7 @@ students.viewStudent.basicTabRelatedActionsManageTransferCreditsLabel = Manage T
 students.viewStudent.basicTabRelatedActionsManageSpokenLanguageExamsLabel = Manage Spoken Language Exams
 students.viewStudent.basicTabRelatedActionsEditStudentImageLabel = Change Student Image
 students.viewStudent.basicTabRelatedActionsCreateStudentParentRegistrationLabel = Create Student Parent Registration
+students.viewStudent.basicTabRelatedActionsCreateMatriculationEnrollmentLabel = Create New Matriculation Enrollment
 students.viewStudent.firstNameTitle = First Name
 students.viewStudent.lastNameTitle = Last Name
 students.viewStudent.nicknameTitle = Nickname
@@ -2724,6 +2719,7 @@ generic.matriculation.enrollmentStates.SUPPLEMENTED = Supplemented
 generic.matriculation.enrollmentStates.APPROVED = Approved
 generic.matriculation.enrollmentStates.REJECTED = Rejected
 generic.matriculation.enrollmentStates.CONFIRMED = Confirmed
+generic.matriculation.enrollmentStates.FILLED_ON_BEHALF = Filled on behalf
 
 generic.matriculation.examGrades.IMPROBATUR = Improbatur
 generic.matriculation.examGrades.APPROBATUR = Approbatur
@@ -2766,6 +2762,8 @@ matriculation.editEnrollment.planned.addRow = Lis‰‰ uusi rivi
 matriculation.editEnrollment.archiveAttendanceConfirmDialogContent = Are you sure you want to remove this attendance? The operation cannot be reverted.
 matriculation.editEnrollment.approvedByGuider = Approved By Guider
 matriculation.editEnrollment.enrollmentDate = Enrollment Date
+matriculation.editEnrollment.newEnrollmentExam = Exam
+matriculation.editEnrollment.newEnrollmentExamEnrollmentDate = enrolled
 matriculation.editEnrollment.degreeStructure = Degree Structure
 matriculation.editEnrollment.degreeStructure.PRE2022 = Old Degree Structure pre 2022
 matriculation.editEnrollment.degreeStructure.POST2022 = New Degree Structure post 2022

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
@@ -192,12 +192,6 @@ terms.search = Hae
 terms.ok = OK
 terms.cancel = Peruuta
 terms.save = Tallenna
-terms.pending = Jätetty
-terms.approved = Hyväksytty
-terms.rejected = Hylätty
-terms.supplementationRequest = Täydennyspyyntö
-terms.supplemented = Täydennetty
-terms.confirmed = Vahvistettu
  
 # Index
 
@@ -1888,6 +1882,7 @@ students.viewStudent.basicTabRelatedActionsManageTransferCreditsLabel = Hallinno
 students.viewStudent.basicTabRelatedActionsManageSpokenLanguageExamsLabel = Hallinnoi suullisen kielitaidon kokeita
 students.viewStudent.basicTabRelatedActionsEditStudentImageLabel = Vaihda opiskelijan kuva
 students.viewStudent.basicTabRelatedActionsCreateStudentParentRegistrationLabel = Luo huoltajatunnuksen luontikutsu
+students.viewStudent.basicTabRelatedActionsCreateMatriculationEnrollmentLabel = Luo uusi ilmoittautuminen YO-kirjoituksiin
 students.viewStudent.firstNameTitle = Etunimi
 students.viewStudent.lastNameTitle = Sukunimi
 students.viewStudent.nicknameTitle = Kutsumanimi
@@ -2724,6 +2719,7 @@ generic.matriculation.enrollmentStates.SUPPLEMENTED = Täydennetty
 generic.matriculation.enrollmentStates.APPROVED = Hyväksytty
 generic.matriculation.enrollmentStates.REJECTED = Peruttu
 generic.matriculation.enrollmentStates.CONFIRMED = Vahvistettu
+generic.matriculation.enrollmentStates.FILLED_ON_BEHALF = Täytetty opiskelijan puolesta
 
 generic.matriculation.examGrades.IMPROBATUR = Improbatur
 generic.matriculation.examGrades.APPROBATUR = Approbatur
@@ -2766,6 +2762,8 @@ matriculation.editEnrollment.planned.addRow = Lisää uusi rivi
 matriculation.editEnrollment.archiveAttendanceConfirmDialogContent = Oletko varma, että haluat poistaa tämän kirjoituskerran? Poistettua kirjoituskertaa ei voida palauttaa.
 matriculation.editEnrollment.approvedByGuider = Ohjaajan hyväksyntä
 matriculation.editEnrollment.enrollmentDate = Ilmoittautumispäivämäärä
+matriculation.editEnrollment.newEnrollmentExam = Ilmoittautumiskierros
+matriculation.editEnrollment.newEnrollmentExamEnrollmentDate = ilmoittautunut
 matriculation.editEnrollment.degreeStructure = Tutkinnon rakenne
 matriculation.editEnrollment.degreeStructure.PRE2022 = Vanha tutkintomuoto ennen 2022
 matriculation.editEnrollment.degreeStructure.POST2022 = Uusi tutkintomuoto 2022

--- a/pyramus/src/main/webapp/templates/matriculation/management-browse-enrollments.jsp
+++ b/pyramus/src/main/webapp/templates/matriculation/management-browse-enrollments.jsp
@@ -43,7 +43,7 @@
                 results[i].email,
                 results[i].state,
                 results[i].numMandatoryCourses,
-                results[i].guider,
+                results[i].guiders,
                 results[i].handler,
                 '']);
             }
@@ -104,7 +104,8 @@
               { text: getLocale().getText("generic.matriculation.enrollmentStates.SUPPLEMENTED"), value: "SUPPLEMENTED" },
               { text: getLocale().getText("generic.matriculation.enrollmentStates.APPROVED"), value: "APPROVED" },
               { text: getLocale().getText("generic.matriculation.enrollmentStates.REJECTED"), value: "REJECTED" },
-              { text: getLocale().getText("generic.matriculation.enrollmentStates.CONFIRMED"), value: "CONFIRMED" }
+              { text: getLocale().getText("generic.matriculation.enrollmentStates.CONFIRMED"), value: "CONFIRMED" },
+              { text: getLocale().getText("generic.matriculation.enrollmentStates.FILLED_ON_BEHALF"), value: "FILLED_ON_BEHALF" }
             ]
           }, {
             header : 'Pakollisia opintoja',
@@ -114,7 +115,7 @@
             editable: false,
             paramName: 'numMandatoryCourses'
           }, {
-            header : 'Ohjaaja',
+            header : 'Ryhmäohjaaja(t)',
             width: 200,
             left: 8 + 300 + 8 + 250 + 8 + 150 + 8 + 130,
             dataType : 'text',

--- a/pyramus/src/main/webapp/templates/matriculation/management-edit-enrollment.jsp
+++ b/pyramus/src/main/webapp/templates/matriculation/management-edit-enrollment.jsp
@@ -319,7 +319,10 @@
     <jsp:include page="/templates/generic/header.jsp"></jsp:include>
 
     <h1 class="genericPageHeader">
-      Muokkaa YO-ilmoittautumisia
+      <c:choose>
+        <c:when test="${formMode == 'NEW'}">Uusi YO-ilmoittautuminen</c:when>
+        <c:otherwise>Muokkaa YO-ilmoittautumista</c:otherwise>
+      </c:choose>
       <a href="${pageContext.request.contextPath}/students/viewstudent.page?person=${enrollment.student.person.id}" class="pyramusViewLink pyramusViewLinkEye">Siirry opiskelijan tietoihin</a>
     </h1>
     
@@ -400,7 +403,7 @@
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.name"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.name.help"/>
                 </jsp:include>            
-                ${fn:escapeXml(name)}
+                ${fn:escapeXml(student.fullName)}
               </div>
   
               <div class="genericFormSection">  
@@ -408,45 +411,27 @@
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.email"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.email.help"/>
                 </jsp:include>            
-                ${fn:escapeXml(email)}
+                ${fn:escapeXml(student.primaryEmail.address)}
               </div>
   
-              <div class="genericFormSection">  
+              <div class="genericFormSection">
                 <jsp:include page="/templates/generic/fragments/formtitle.jsp">
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.phone"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.phone.help"/>
-                </jsp:include>            
-                ${fn:escapeXml(phone)}
+                </jsp:include>
+                ${fn:escapeXml(student.primaryPhoneNumber.number)}
               </div>
             </div>
-
+              
             <div class="genericViewInfoWapper">
-              <div class="genericFormSection">
-                <jsp:include page="/templates/generic/fragments/formtitle.jsp">
-                  <jsp:param name="titleLocale" value="matriculation.editEnrollment.degreeStructure"/>
-                  <jsp:param name="helpLocale" value="matriculation.editEnrollment.degreeStructure.help"/>
-                </jsp:include>            
-                <select class="required" name="degreeStructure">
-                  <option></option>
-                  <option ${degreeStructure=='PRE2022' ? 'selected="selected"' : ''} value="PRE2022"><fmt:message key="matriculation.editEnrollment.degreeStructure.PRE2022"/></option>
-                  <option ${degreeStructure=='POST2022' ? 'selected="selected"' : ''} value="POST2022"><fmt:message key="matriculation.editEnrollment.degreeStructure.POST2022"/></option>
-                </select>
-              </div>
-
-              <div class="genericFormSection">
-                <jsp:include page="/templates/generic/fragments/formtitle.jsp">
-                  <jsp:param name="titleLocale" value="matriculation.editEnrollment.nationalStudentNumber"/>
-                  <jsp:param name="helpLocale" value="matriculation.editEnrollment.nationalStudentNumber.help"/>
-                </jsp:include>            
-                <input type="text" name="nationalStudentNumber" value="${fn:escapeXml(nationalStudentNumber)}">
-              </div>
-  
               <div class="genericFormSection">
                 <jsp:include page="/templates/generic/fragments/formtitle.jsp">
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.guidanceCounselor"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.guidanceCounselor.help"/>
-                </jsp:include>            
-                <input type="text" name="guidanceCounselor" value="${fn:escapeXml(guidanceCounselor)}" size="40"/>
+                </jsp:include>
+                <c:forEach var="groupAdvisor" items="${groupAdvisors}">
+                  <div>${fn:escapeXml(groupAdvisor.staffMember.fullName)}</div>
+                </c:forEach>
               </div>
   
               <div class="genericFormSection">
@@ -459,16 +444,88 @@
                   <div>${fn:escapeXml(studyAdvisor.staffMember.fullName)}</div>
                 </c:forEach>
               </div>
+            </div>
+
+            <div class="genericViewInfoWapper">
+              <div class="genericFormSection">
+                <jsp:include page="/templates/generic/fragments/formtitle.jsp">
+                  <jsp:param name="titleLocale" value="matriculation.editEnrollment.newEnrollmentExam"/>
+                  <jsp:param name="helpLocale" value="matriculation.editEnrollment.newEnrollmentExam.help"/>
+                </jsp:include>
+                <c:choose>
+                  <c:when test="${formMode eq 'NEW'}">
+                    <select class="required" name="examId">
+                      <option></option>
+                      <c:forEach var="exam" items="${exams}">
+                        <c:choose>
+                          <c:when test="${exam.exam.examTerm == 'SPRING'}">
+                            <c:set var="examTermText"><fmt:message key="terms.seasons.spring" /></c:set>
+                          </c:when>
+                          <c:when test="${exam.exam.examTerm == 'AUTUMN'}">
+                            <c:set var="examTermText"><fmt:message key="terms.seasons.autumn" /></c:set>
+                          </c:when>
+                          <c:otherwise>
+                            <c:set var="examTermText"></c:set>
+                          </c:otherwise>
+                        </c:choose>
+                        <option ${!empty exam.enrollment ? 'disabled="disabled"' : ''} value="${exam.exam.id}">
+                          ${exam.exam.examYear} ${examTermText}
+                          <c:if test="${!empty exam.enrollment}">
+                            (<fmt:message key="matriculation.editEnrollment.newEnrollmentExamEnrollmentDate"/> <fmt:formatDate value="${exam.enrollment.enrollmentDate}" />)
+                          </c:if>
+                        </option>
+                      </c:forEach>
+                    </select>
+                  </c:when>
+                  <c:otherwise>
+                    <c:choose>
+                      <c:when test="${enrollment.exam.examTerm == 'SPRING'}">
+                        <c:set var="examTermText"><fmt:message key="terms.seasons.spring" /></c:set>
+                      </c:when>
+                      <c:when test="${enrollment.exam.examTerm == 'AUTUMN'}">
+                        <c:set var="examTermText"><fmt:message key="terms.seasons.autumn" /></c:set>
+                      </c:when>
+                      <c:otherwise>
+                        <c:set var="examTermText"></c:set>
+                      </c:otherwise>
+                    </c:choose>
+                    ${enrollment.exam.examYear} ${examTermText}
+                  </c:otherwise>
+                </c:choose>
+              </div>
+
+              <div class="genericFormSection">
+                <jsp:include page="/templates/generic/fragments/formtitle.jsp">
+                  <jsp:param name="titleLocale" value="matriculation.editEnrollment.nationalStudentNumber"/>
+                  <jsp:param name="helpLocale" value="matriculation.editEnrollment.nationalStudentNumber.help"/>
+                </jsp:include>            
+                <input type="text" name="nationalStudentNumber" value="${fn:escapeXml(enrollment.nationalStudentNumber)}">
+              </div>
   
+              <div class="genericFormSection">
+                <jsp:include page="/templates/generic/fragments/formtitle.jsp">
+                  <jsp:param name="titleLocale" value="matriculation.editEnrollment.degreeStructure"/>
+                  <jsp:param name="helpLocale" value="matriculation.editEnrollment.degreeStructure.help"/>
+                </jsp:include>            
+                <select class="required" name="degreeStructure">
+                  <option></option>
+                  <option ${enrollment.degreeStructure=='PRE2022' ? 'selected="selected"' : ''} value="PRE2022"><fmt:message key="matriculation.editEnrollment.degreeStructure.PRE2022"/></option>
+                  <option ${enrollment.degreeStructure=='POST2022' ? 'selected="selected"' : ''} value="POST2022"><fmt:message key="matriculation.editEnrollment.degreeStructure.POST2022"/></option>
+                </select>
+              </div>
+
               <div class="genericFormSection">
                 <jsp:include page="/templates/generic/fragments/formtitle.jsp">
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.enrollAs"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.enrollAs.help"/>
                 </jsp:include>            
                 <select class="required" name="enrollAs">
-                  <option ${enrollAs=='UPPERSECONDARY' ? 'selected="selected"' : ''} value="UPPERSECONDARY">Lukio-opinnot</option>
-                  <option ${enrollAs=='VOCATIONAL' ? 'selected="selected"' : ''} value="VOCATIONAL">Ammatilliset opinnot</option>
-                  <option ${enrollAs=='UNKNOWN' ? 'selected="selected"' : ''} value="UNKNOWN">Muu tausta</option>
+                  <c:if test="${formMode == 'NEW'}">
+                    <option></option>
+                  </c:if>
+                  <option ${enrollment.enrollAs=='UPPERSECONDARY' ? 'selected="selected"' : ''} value="UPPERSECONDARY">Lukio-opinnot</option>
+                  <option ${enrollment.enrollAs=='VOCATIONAL' ? 'selected="selected"' : ''} value="VOCATIONAL">Ammatilliset opinnot</option>
+                  <option ${enrollment.enrollAs=='UNKNOWN' ? 'selected="selected"' : ''} value="UNKNOWN">Muu tausta</option>
                 </select>
               </div>
   
@@ -494,6 +551,9 @@
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.degreeType.help"/>
                 </jsp:include>            
                 <select class="required" name="degreeType">
+                  <c:if test="${formMode == 'NEW'}">
+                    <option></option>
+                  </c:if>
                   <option ${enrollment.degreeType=='MATRICULATIONEXAMINATION' ? 'selected="selected"' : ''} value="MATRICULATIONEXAMINATION">Yo-tutkinto</option>
                   <option ${enrollment.degreeType=='MATRICULATIONEXAMINATIONSUPPLEMENT' ? 'selected="selected"' : ''} value="MATRICULATIONEXAMINATIONSUPPLEMENT">Tutkinnon korottaja tai täydentäjä</option>
                   <option ${enrollment.degreeType=='SEPARATEEXAM' ? 'selected="selected"' : ''} value="SEPARATEEXAM">Erillinen koe (ilman yo-tutkintoa)</option>
@@ -505,7 +565,7 @@
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.location"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.location.help"/>
                 </jsp:include>            
-                <input type="text" name="location" value="${fn:escapeXml(location)}">
+                <input type="text" name="location" value="${fn:escapeXml(enrollment.location)}">
               </div>
   
               <div class="genericFormSection">
@@ -521,7 +581,7 @@
                   <jsp:param name="titleLocale" value="matriculation.editEnrollment.message"/>
                   <jsp:param name="helpLocale" value="matriculation.editEnrollment.message.help"/>
                 </jsp:include>            
-                <textarea name="message" cols="80" rows="8">${fn:escapeXml(message)}</textarea>
+                <textarea name="message" cols="80" rows="8">${fn:escapeXml(enrollment.message)}</textarea>
               </div>
   
               <div class="genericFormSection">
@@ -579,6 +639,7 @@
                   <option ${state=='APPROVED' ? 'selected="selected"' : ''} ${!allowedStates.contains('APPROVED') ? 'disabled="disabled"' : ''} value="APPROVED"><fmt:message key="generic.matriculation.enrollmentStates.APPROVED"/></option>
                   <option ${state=='REJECTED' ? 'selected="selected"' : ''} ${!allowedStates.contains('REJECTED') ? 'disabled="disabled"' : ''} value="REJECTED"><fmt:message key="generic.matriculation.enrollmentStates.REJECTED"/></option>
                   <option ${state=='CONFIRMED' ? 'selected="selected"' : ''} ${!allowedStates.contains('CONFIRMED') ? 'disabled="disabled"' : ''} value="CONFIRMED"><fmt:message key="generic.matriculation.enrollmentStates.CONFIRMED"/></option>
+                  <option ${state=='FILLED_ON_BEHALF' ? 'selected="selected"' : ''} ${!allowedStates.contains('FILLED_ON_BEHALF') ? 'disabled="disabled"' : ''} value="FILLED_ON_BEHALF"><fmt:message key="generic.matriculation.enrollmentStates.FILLED_ON_BEHALF"/></option>
                 </select>
               </div>
 

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -164,6 +164,12 @@
           }
         }));
 
+        basicTabRelatedActionsHoverMenu.addItem(new IxHoverMenuLinkItem({
+          iconURL: GLOBAL_contextPath + '/gfx/list-add.png',
+          text: '<fmt:message key="students.viewStudent.basicTabRelatedActionsCreateMatriculationEnrollmentLabel"/>',
+          link: GLOBAL_contextPath + '/matriculation/edit.page?student=' + studentId
+        }));
+
         var studentReports = JSDATA["studentReports"].evalJSON();
         
         if (studentReports) {
@@ -3120,32 +3126,37 @@
                             <c:choose>
                               <c:when test="${enrollment.state == 'PENDING'}">
                                 <c:set var="matriculationExamEnrollmentState">
-                                  <fmt:message key="terms.pending"/>
+                                  <fmt:message key="generic.matriculation.enrollmentStates.PENDING"/>
                                 </c:set>
                               </c:when>
                               <c:when test="${enrollment.state == 'SUPPLEMENTATION_REQUEST'}">
                                 <c:set var="matriculationExamEnrollmentState">
-                                  <fmt:message key="terms.supplementationRequest"/>
+                                  <fmt:message key="generic.matriculation.enrollmentStates.SUPPLEMENTATION_REQUEST"/>
                                 </c:set>
                               </c:when>
                               <c:when test="${enrollment.state == 'SUPPLEMENTED'}">
                                 <c:set var="matriculationExamEnrollmentState">
-                                  <fmt:message key="terms.supplemented"/>
+                                  <fmt:message key="generic.matriculation.enrollmentStates.SUPPLEMENTED"/>
                                 </c:set>
                               </c:when>
                               <c:when test="${enrollment.state == 'APPROVED'}">
                                 <c:set var="matriculationExamEnrollmentState">
-                                  <fmt:message key="terms.approved"/>
+                                  <fmt:message key="generic.matriculation.enrollmentStates.APPROVED"/>
                                 </c:set>
                               </c:when>
                               <c:when test="${enrollment.state == 'REJECTED'}">
                                 <c:set var="matriculationExamEnrollmentState">
-                                  <fmt:message key="terms.rejected"/>
+                                  <fmt:message key="generic.matriculation.enrollmentStates.REJECTED"/>
                                 </c:set>
                               </c:when>
                               <c:when test="${enrollment.state == 'CONFIRMED'}">
                                 <c:set var="matriculationExamEnrollmentState">
-                                  <fmt:message key="terms.confirmed"/>
+                                  <fmt:message key="generic.matriculation.enrollmentStates.CONFIRMED"/>
+                                </c:set>
+                              </c:when>
+                              <c:when test="${enrollment.state == 'FILLED_ON_BEHALF'}">
+                                <c:set var="matriculationExamEnrollmentState">
+                                  <fmt:message key="generic.matriculation.enrollmentStates.FILLED_ON_BEHALF"/>
                                 </c:set>
                               </c:when>
                               <c:otherwise>

--- a/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/MatriculationExamEnrollment.java
+++ b/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/MatriculationExamEnrollment.java
@@ -21,14 +21,6 @@ public class MatriculationExamEnrollment {
     this.nationalStudentNumber = nationalStudentNumber;
   }
 
-  public String getGuider() {
-    return guider;
-  }
-
-  public void setGuider(String guider) {
-    this.guider = guider;
-  }
-
   public String getEnrollAs() {
     return enrollAs;
   }
@@ -143,7 +135,6 @@ public class MatriculationExamEnrollment {
 
   private Long id;
   private Long nationalStudentNumber;
-  private String guider;
   private String enrollAs;
   private String degreeType;
   private int numMandatoryCourses;

--- a/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/MatriculationExamStudentStatus.java
+++ b/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/MatriculationExamStudentStatus.java
@@ -17,6 +17,8 @@ public enum MatriculationExamStudentStatus {
   // Enrollment has been rejected (implies the form was also submitted before)
   REJECTED,
   // Confirmed by student
-  CONFIRMED
-  
+  CONFIRMED,
+  // Form filled on behalf of the student
+  FILLED_ON_BEHALF;
+
 }

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/MatriculationRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/MatriculationRESTService.java
@@ -417,7 +417,6 @@ public class MatriculationRESTService extends AbstractRESTService {
         enrollmentEntity = matriculationExamEnrollmentDao.create(
           exam,
           enrollment.getNationalStudentNumber(),
-          enrollment.getGuider(),
           SchoolType.valueOf(enrollment.getEnrollAs()),
           DegreeType.valueOf(enrollment.getDegreeType()),
           enrollment.getNumMandatoryCourses(),
@@ -463,7 +462,6 @@ public class MatriculationRESTService extends AbstractRESTService {
         
         enrollmentEntity = matriculationExamEnrollmentDao.update(
           existingEnrollment,
-          enrollment.getGuider(),
           SchoolType.valueOf(enrollment.getEnrollAs()),
           DegreeType.valueOf(enrollment.getDegreeType()),
           enrollment.getNumMandatoryCourses(),
@@ -649,7 +647,6 @@ public class MatriculationRESTService extends AbstractRESTService {
     result.setId(examEnrollment.getId());
     result.setExamId(examEnrollment.getExam().getId());
     result.setNationalStudentNumber(examEnrollment.getNationalStudentNumber());
-    result.setGuider(examEnrollment.getGuider());
     result.setEnrollAs(examEnrollment.getEnrollAs().name());
     result.setDegreeType(examEnrollment.getDegreeType().name());
     result.setNumMandatoryCourses(examEnrollment.getNumMandatoryCourses());

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/MatriculationEligibilityController.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/controller/MatriculationEligibilityController.java
@@ -296,6 +296,8 @@ public class MatriculationEligibilityController {
         return MatriculationExamStudentStatus.REJECTED;
       case CONFIRMED:
         return MatriculationExamStudentStatus.CONFIRMED;
+      case FILLED_ON_BEHALF:
+        return MatriculationExamStudentStatus.FILLED_ON_BEHALF;
       default:
         throw new IllegalArgumentException();
     }
@@ -315,6 +317,8 @@ public class MatriculationEligibilityController {
         return MatriculationExamEnrollmentState.REJECTED;
       case CONFIRMED:
         return MatriculationExamEnrollmentState.CONFIRMED;
+      case FILLED_ON_BEHALF:
+        return MatriculationExamEnrollmentState.FILLED_ON_BEHALF;
       case ELIGIBLE:
       case NOT_ELIGIBLE:
       default:


### PR DESCRIPTION
**YO-ilmoittautuminen**
- Lisätty mahdollisuus syöttää YO-ilmoittautuminen opiskelijan puolesta
- Lisätty terminaalitila ylläolevalle, jottei se sekoitu normaaliin ilmoittautumis-/vahvistusprosessiin 
- Muutettu lomakkeen tiedoissa näkyvät ryhmäohjaajat näkymään listana, joka haetaan opiskelijaryhmien ohjaajista
- Muutettu lomakkeiden haku hakemaan opiskelijaryhmien ryhmäohjaajista aiemman `guider`-kentän sijaan 
- Poistettu `guider`-kenttä lomakkeen tiedoista (korvattu ylläolevalla)

**Muut**
- Koski-mitätöinti muutettu käyttämään pelkästään nykyistä päivämäärää (jos opiskeluoikeus oli merkitty tulevaisuuteen, mitätöinti käytti sitä päivämäärää ja Koski ei tätä hyväksy)

Closes #1701 
Closes #1702 
Closes #1703 
Fixes #1705 