### PR TITLE
Oppivelvollisten maksuttomuusjaksojen säätöä

### DIFF
--- a/framework/src/main/java/fi/otavanopisto/pyramus/applications/ApplicationUtils.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/applications/ApplicationUtils.java
@@ -1195,18 +1195,19 @@ public class ApplicationUtils {
     String compulsoryStudies = getFormValue(formData, "field-nettilukio_compulsory");
     if (StringUtils.isNotBlank(compulsoryStudies)) {
       if (StringUtils.equals(compulsoryStudies, "compulsory")) {
-        studentStudyPeriodDAO.create(student, studyStartDate, null, StudentStudyPeriodType.COMPULSORY_EDUCATION);
-      
+        Date compulsoryEndDate = null;
+
         String compulsoryEndDateStr = getFormValue(formData, "field-nettilukio_compulsory_enddate");
         if (StringUtils.isNotBlank(compulsoryEndDateStr)) {
           try {
-            Date compulsoryEndDate = StringUtils.isBlank(compulsoryEndDateStr) ? null : new SimpleDateFormat("d.M.yyyy").parse(compulsoryEndDateStr);
-            studentStudyPeriodDAO.create(student, compulsoryEndDate, null, StudentStudyPeriodType.NON_COMPULSORY_EDUCATION);
+            compulsoryEndDate = StringUtils.isBlank(compulsoryEndDateStr) ? null : new SimpleDateFormat("d.M.yyyy").parse(compulsoryEndDateStr);
           } catch (ParseException e) {
             logger.severe(String.format("Invalid compulsory end date format in application entity %d", application.getId()));
             return null;
           }
         }
+
+        studentStudyPeriodDAO.create(student, studyStartDate, compulsoryEndDate, StudentStudyPeriodType.COMPULSORY_EDUCATION);
       } 
       else if (StringUtils.equals(compulsoryStudies, "non_compulsory")) {
         studentStudyPeriodDAO.create(student, studyStartDate, null, StudentStudyPeriodType.NON_COMPULSORY_EDUCATION);

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AbstractAikuistenPerusopetuksenHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/aikuistenperusopetus/AbstractAikuistenPerusopetuksenHandler.java
@@ -1,10 +1,12 @@
 package fi.otavanopisto.pyramus.koski.model.aikuistenperusopetus;
 
+import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
 
 import fi.otavanopisto.pyramus.dao.students.StudentStudyPeriodDAO;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
@@ -43,6 +45,17 @@ public abstract class AbstractAikuistenPerusopetuksenHandler extends KoskiStuden
       if (studyPeriod.getPeriodType() == StudentStudyPeriodType.COMPULSORY_EDUCATION) {
         // Maksuttoman oppivelvollisuuden piirissä
         lisatiedot.addMaksuttomuus(new Maksuttomuus(studyPeriod.getBegin(), true));
+        
+        // Ei maksuttoman oppivelvollisuuden piirissä (jos päättymispäivä asetettu)
+        if (studyPeriod.getEnd() != null) {
+          // Loogisesti jakso alkaa seuraavasta päivästä, joten lisätään yksi päivä
+          Date eiMaksullinenAlkaen = DateUtils.addDays(studyPeriod.getEnd(), 1);
+
+          // Jos opintojen päättymispäivä on asetettu niin jakson päivämäärän pitää olla sitä ennen, muutoin jätetään pois
+          if (student.getStudyEndDate() == null || eiMaksullinenAlkaen.before(student.getStudyEndDate())) {
+            lisatiedot.addMaksuttomuus(new Maksuttomuus(eiMaksullinenAlkaen, false));
+          }
+        }
       }
       
       if (studyPeriod.getPeriodType() == StudentStudyPeriodType.NON_COMPULSORY_EDUCATION) {

--- a/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/AbstractKoskiLukioStudentHandler.java
+++ b/framework/src/main/java/fi/otavanopisto/pyramus/koski/model/lukio/AbstractKoskiLukioStudentHandler.java
@@ -1,11 +1,13 @@
 package fi.otavanopisto.pyramus.koski.model.lukio;
 
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
 
 import fi.otavanopisto.pyramus.dao.students.StudentStudyPeriodDAO;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
@@ -68,6 +70,17 @@ public abstract class AbstractKoskiLukioStudentHandler extends KoskiStudentHandl
       if (studyPeriod.getPeriodType() == StudentStudyPeriodType.COMPULSORY_EDUCATION) {
         // Maksuttoman oppivelvollisuuden piirissä
         lisatiedot.addMaksuttomuus(new Maksuttomuus(studyPeriod.getBegin(), true));
+        
+        // Ei maksuttoman oppivelvollisuuden piirissä (jos päättymispäivä asetettu)
+        if (studyPeriod.getEnd() != null) {
+          // Loogisesti jakso alkaa seuraavasta päivästä, joten lisätään yksi päivä
+          Date eiMaksullinenAlkaen = DateUtils.addDays(studyPeriod.getEnd(), 1);
+
+          // Jos opintojen päättymispäivä on asetettu niin jakson päivämäärän pitää olla sitä ennen, muutoin jätetään pois
+          if (student.getStudyEndDate() == null || eiMaksullinenAlkaen.before(student.getStudyEndDate())) {
+            lisatiedot.addMaksuttomuus(new Maksuttomuus(eiMaksullinenAlkaen, false));
+          }
+        }
       }
       
       if (studyPeriod.getPeriodType() == StudentStudyPeriodType.NON_COMPULSORY_EDUCATION) {

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentStudyPeriodType.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentStudyPeriodType.java
@@ -12,7 +12,6 @@ public enum StudentStudyPeriodType {
 
   public static final EnumSet<StudentStudyPeriodType> BEGINDATE_ONLY = EnumSet.of(
       PROLONGED_STUDYENDDATE,
-      COMPULSORY_EDUCATION,
       NON_COMPULSORY_EDUCATION
   );
   

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/applications/ViewApplicationViewController.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/applications/ViewApplicationViewController.java
@@ -122,7 +122,7 @@ public class ViewApplicationViewController extends PyramusViewController {
         if (StringUtils.equals(compulsoryStudies, "compulsory")) {
           String compulsoryEndDateStr = getFormValue(formData, "field-nettilukio_compulsory_enddate");
           if (StringUtils.isNotBlank(compulsoryEndDateStr)) {
-            fields.put("Maksuton oppivelvollisuus päättynyt alkaen", compulsoryEndDateStr);
+            fields.put("Maksuton oppivelvollisuus päättyy", compulsoryEndDateStr);
           }
         }
       }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentTools.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentTools.java
@@ -9,6 +9,7 @@ import fi.otavanopisto.pyramus.dao.DAOFactory;
 import fi.otavanopisto.pyramus.dao.students.StudentStudyPeriodDAO;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
 import fi.otavanopisto.pyramus.domainmodel.students.StudentStudyPeriod;
+import fi.otavanopisto.pyramus.domainmodel.students.StudentStudyPeriodType;
 import fi.otavanopisto.pyramus.framework.DateUtils;
 import fi.otavanopisto.pyramus.views.students.ViewStudentValidationWarning.ViewStudentValidationType;
 import fi.otavanopisto.pyramus.views.students.ViewStudentValidationWarning.ViewStudentValidationWarningSeverity;
@@ -41,6 +42,24 @@ public class ViewStudentTools {
           (studyPeriod.getEnd() != null && !DateUtils.isWithin(studyPeriod.getEnd(), student.getStudyStartDate(), student.getStudyEndDate()))) {
         warnings.add(new ViewStudentValidationWarning(student, ViewStudentValidationType.STUDYPERIOD_OUTSIDE_STUDYTIME,
             ViewStudentValidationWarningSeverity.ERROR));
+      }
+      
+      // There should always be an end to compulsory education periods if the student is an active student
+      if (studyPeriod.getPeriodType() == StudentStudyPeriodType.COMPULSORY_EDUCATION && student.getStudyEndDate() == null) {
+        if (studyPeriod.getEnd() == null) {
+          boolean hasNonCompulsoryPeriod = false;
+          for (StudentStudyPeriod studyPeriod2 : studyPeriods) {
+            if (studyPeriod2.getPeriodType() == StudentStudyPeriodType.NON_COMPULSORY_EDUCATION && studyPeriod2.getBegin().after(studyPeriod.getBegin())) {
+              hasNonCompulsoryPeriod = true;
+              break;
+            }
+          }
+          
+          if (!hasNonCompulsoryPeriod) {
+            warnings.add(new ViewStudentValidationWarning(student, ViewStudentValidationType.STUDYPERIOD_COMPULSORY_EDUCATION_NO_END,
+                ViewStudentValidationWarningSeverity.ERROR));
+          }
+        }
       }
     }
     

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentValidationWarning.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentValidationWarning.java
@@ -12,6 +12,8 @@ public class ViewStudentValidationWarning {
     STUDYENDDATE_BEFORE_STARTDATE,
     // Some StudyPeriod for the Student is not within the timeframe of studyStartDate to studyEndDate
     STUDYPERIOD_OUTSIDE_STUDYTIME,
+    // Compulsory Education StudyPeriod doesn't end
+    STUDYPERIOD_COMPULSORY_EDUCATION_NO_END,
     // Default user is not set
     DEFAULT_USER_NOT_SET,
     // Default user is archived

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale.properties
@@ -175,6 +175,7 @@ generic.studentStudyPeriods.EXTENDED_COMPULSORY_EDUCATION = Prolonged Compulsory
 
 generic.pyramusStudentValidationErrors.STUDYENDDATE_BEFORE_STARTDATE = Study end date precedes study start date
 generic.pyramusStudentValidationErrors.STUDYPERIOD_OUTSIDE_STUDYTIME = Study period is outside study time
+generic.pyramusStudentValidationErrors.STUDYPERIOD_COMPULSORY_EDUCATION_NO_END = Compulsory education study period is missing an end date
 generic.pyramusStudentValidationErrors.DEFAULT_USER_NOT_SET = Default user is not set
 generic.pyramusStudentValidationErrors.DEFAULT_USER_ARCHIVED = Default user is archived
 generic.pyramusStudentValidationErrors.OVERLAPPING_STUDY_RIGHTS = The student has overlapping study rights at the same educational level
@@ -1894,7 +1895,7 @@ students.viewStudent.studyEndReasonTitle = Study End Reason
 students.viewStudent.studyEndTextTitle = Study End Description
 students.viewStudent.matriculationExamEnrollmentsTitle = Matriculation Exam Enrollments
 students.viewStudent.studyPeriodsTitle = Study Periods
-students.viewStudent.studyPeriodCompulsoryEducationEndDate = (compulsory education ends at {0})
+students.viewStudent.studyPeriodCompulsoryEducationEndDate = By default compulsory education ends at the end of the year when student turns 20 years old. For this student {0}. If the period has an end date, the studies are automatically marked non-compulsory starting from the next day.
 students.viewStudent.lodgingTitle = Lodging
 students.viewStudent.createButton = Create Student
 students.viewStudent.birthdayTitle = Birthday

--- a/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
+++ b/pyramus/src/main/resources/fi/otavanopisto/pyramus/I18N/pyramuslocale_fi_FI.properties
@@ -175,6 +175,7 @@ generic.studentStudyPeriods.EXTENDED_COMPULSORY_EDUCATION = Maksuttoman oppivelv
 
 generic.pyramusStudentValidationErrors.STUDYENDDATE_BEFORE_STARTDATE = Opintojen p‰‰ttymisaika on ennen opintojen alkamisaikaa
 generic.pyramusStudentValidationErrors.STUDYPERIOD_OUTSIDE_STUDYTIME = Opiskelujakson ajankohta on opintoajan ulkopuolella
+generic.pyramusStudentValidationErrors.STUDYPERIOD_COMPULSORY_EDUCATION_NO_END = Maksuttoman oppivelvollisuuden opiskelujaksolle ei ole m‰‰ritetty p‰‰ttymisajankohtaa
 generic.pyramusStudentValidationErrors.DEFAULT_USER_NOT_SET = Henkilˆn oletusk‰ytt‰j‰‰ ei ole asetettu
 generic.pyramusStudentValidationErrors.DEFAULT_USER_ARCHIVED = Henkilˆn oletusk‰ytt‰j‰ on arkistoitu
 generic.pyramusStudentValidationErrors.OVERLAPPING_STUDY_RIGHTS = Opiskelijalla on p‰‰llekk‰isi‰ opiskeluoikeuksia samalla koulutusasteella
@@ -1894,7 +1895,7 @@ students.viewStudent.studyEndReasonTitle = Opintojen p‰‰ttymissyy
 students.viewStudent.studyEndTextTitle = Opintojen p‰‰ttymissyyn lis‰tietoja
 students.viewStudent.matriculationExamEnrollmentsTitle = Yo-kokeiden ilmoittautumiset
 students.viewStudent.studyPeriodsTitle = Opiskelujaksot
-students.viewStudent.studyPeriodCompulsoryEducationEndDate = (maksuton oppivelvollisuus p‰‰ttyy {0})
+students.viewStudent.studyPeriodCompulsoryEducationEndDate = Oletusarvoisesti maksuton oppivelvollisuus p‰‰ttyy sen kalenterivuoden lopussa jolloin opiskelija t‰ytt‰‰ 20v. T‰m‰n opiskelijan kohdalla {0}. Jos jaksolle on m‰‰ritetty p‰‰ttymisp‰iv‰, niin sit‰ seuraavasta p‰iv‰st‰ opiskelijan opinnot merkit‰‰n automaattisesti maksulliseksi.
 students.viewStudent.lodgingTitle = Asuminen
 students.viewStudent.createButton = Luo Student
 students.viewStudent.birthdayTitle = Syntym‰aika

--- a/pyramus/src/main/webapp/scripts/gui/applications/application.js
+++ b/pyramus/src/main/webapp/scripts/gui/applications/application.js
@@ -150,6 +150,37 @@
       updateProgress();
     });
     
+    // Compulsory end date
+
+    $('#field-nettilukio_compulsory').on('change', function() {
+      if ($('#field-nettilukio_compulsory').val() == 'compulsory') {
+        var compulsoryEndDate = null;
+        var ssn = $('#field-ssn').val();
+        if (ssn && ssn.length == 11) {
+          var y = parseInt(ssn.substring(4, 6));
+          if ('ABCDEF'.indexOf(ssn.charAt(6).toUpperCase()) >= 0) {
+            y += 2000;
+          }
+          else {
+            y += 1900;
+          }
+          compulsoryEndDate = new Date(y + 20, 11, 31);
+        }
+        else if ($('#field-birthday').val()) {
+          compulsoryEndDate = moment($('#field-birthday').val(), "D.M.YYYY");
+          compulsoryEndDate.setFullYear(compulsoryEndDate.getFullYear() + 20);
+          compulsoryEndDate.setMonth(11);
+          compulsoryEndDate.setDate(31);
+        }
+        if (compulsoryEndDate != null) {
+          $('#field-nettilukio_compulsory_enddate').val(moment(compulsoryEndDate).format('D.M.YYYY'));
+        }
+      }
+      else {
+        $('#field-nettilukio_compulsory_enddate').val('');
+      }
+    });
+    
     // Custom validators
     
     Parsley.addValidator('dateFormat', {

--- a/pyramus/src/main/webapp/scripts/ixtable/ixtable.js
+++ b/pyramus/src/main/webapp/scripts/ixtable/ixtable.js
@@ -1989,6 +1989,57 @@ IxButtonTableEditorButtonController = Class.create(IxTableEditorController, {
 
 IxTableControllers.registerController(new IxButtonTableEditorButtonController());
 
+IxIconTableEditorController = Class.create(IxTableEditorController, {
+  buildViewer: function ($super, name, columnDefinition) {
+    if (columnDefinition.imgsrc) {  
+      var cellViewer = new Element("img", { src: columnDefinition.imgsrc, title: columnDefinition.tooltip ? columnDefinition.tooltip : '', className: "ixTableCellViewer"});
+      
+      if (columnDefinition.viewerClassNames) {
+        var classNames = columnDefinition.viewerClassNames.split(' ');
+        for (var i = 0, l = classNames.length; i < l; i++) {
+          cellViewer.addClassName(classNames[i]);
+        }
+      }
+      
+      cellViewer._editable = false;
+      cellViewer._dataType = this.getDataType();
+      cellViewer._name = name;
+      cellViewer._columnDefinition = columnDefinition;
+      
+      return cellViewer;
+    }
+    else {
+      throw new Error("Unable to build icon without image");
+    }
+  },
+  attachContentHandler: function ($super, table, cell, handlerInstance) {
+    $super(table, cell, handlerInstance);
+  },
+  detachContentHandler: function ($super, handlerInstance) {
+    $super(handlerInstance);
+  }, 
+  disableEditor: function ($super, handlerInstance) {
+    handlerInstance._disabled = true;
+  },
+  enableEditor: function ($super, handlerInstance) {
+    handlerInstance._disabled = false;
+  },
+  destroyEditor: function ($super, handlerInstance) {
+    handlerInstance.remove();
+  },
+  isDisabled: function ($super, handlerInstance) {
+    return handlerInstance._disabled == true;
+  },
+  getDataType: function ($super) {
+    return "icon";
+  },
+  getMode: function ($super) {
+    return IxTableControllers.EDITMODE_NOT_EDITABLE;
+  }
+});
+
+IxTableControllers.registerController(new IxIconTableEditorController());
+
 IxTextTableEditorController = Class.create(IxTableEditorController, {
   buildEditor: function ($super, name, columnDefinition) {
     var editor = this._createEditorElement("input", name, "ixTableCellEditorText", {name: name, type: "text"}, columnDefinition);

--- a/pyramus/src/main/webapp/templates/applications/form-sections/application-form-section-selection.jsp
+++ b/pyramus/src/main/webapp/templates/applications/form-sections/application-form-section-selection.jsp
@@ -78,7 +78,7 @@
         </div>
   
         <div class="form-section__field-container" data-dependent-field="field-nettilukio_compulsory" data-dependent-values="compulsory" style="display:none;">
-          <label for="field-nettilukio_compulsory_enddate">Maksuton oppivelvollisuus päättynyt alkaen</label>
+          <label for="field-nettilukio_compulsory_enddate">Maksuton oppivelvollisuus päättyy</label>
           <input type="text" id="field-nettilukio_compulsory_enddate" name="field-nettilukio_compulsory_enddate" data-parsley-date-format="" />
         </div>
       </div>

--- a/pyramus/src/main/webapp/templates/students/editstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/editstudent.jsp
@@ -466,7 +466,7 @@
           }, {
             header : '<fmt:message key="students.editStudent.studyPeriodsTable.type"/>',
             left : 8 + 160 + 8,
-            width : 200,
+            width : 300,
             dataType: 'select',
             editable: true,
             required: true,
@@ -474,14 +474,14 @@
             options: studentStudyPeriodTypeOptions
           }, {
             header: '<fmt:message key="students.editStudent.studyPeriodsTable.end"/>',
-            left : 8 + 160 + 8 + 200 + 8,
+            left : 8 + 160 + 8 + 300 + 8,
             width: 160,
             dataType : 'date',
             editable: true,
             paramName: 'end'
           }, {
             width: 30,
-            left: 8 + 160 + 8 + 200 + 8 + 160 + 8,
+            left: 8 + 160 + 8 + 300 + 8 + 160 + 8,
             dataType: 'button',
             paramName: 'removeButton',
             imgsrc: GLOBAL_contextPath + '/gfx/list-remove.png',
@@ -491,11 +491,13 @@
             }
           }, {
             header: '',
-            left : 8 + 160 + 8 + 200 + 8 + 160 + 8 + 22 + 8,
-            width: 300,
-            dataType : 'text',
+            left : 8 + 160 + 8 + 300 + 8 + 160 + 8 + 22 + 8,
+            width: 22,
+            dataType : 'icon',
             editable: false,
-            paramName: 'message'
+            paramName: 'message',
+            imgsrc: GLOBAL_contextPath + '/gfx/icons/16x16/apps/help-browser.png',
+            tooltip: '${compulsoryEducationEndDateMessage}',
           }]
         });
 
@@ -515,6 +517,25 @@
             
             if (event.value == 'COMPULSORY_EDUCATION') {
               table.showCell(event.row, table.getNamedColumnIndex('message'));
+              
+              // Prefill compulsory end date with the date at end of year when student turns 20
+              // But only do so when the row is new (i.e. the id doesn't exist)
+              if (table.getCellValue(event.row, table.getNamedColumnIndex('id')) == -1) {
+                var endDateColumnIndex = table.getNamedColumnIndex('end');
+                var endDateValue = table.getCellValue(event.row, endDateColumnIndex);
+                if (!endDateValue) {
+                  var birthdayField = getIxDateField("birthday");
+                  var birthdayTimestamp = birthdayField ? birthdayField.getTimestamp() : null;
+                  if (birthdayTimestamp) {
+                    var compulsoryEndDate = new Date();
+                    compulsoryEndDate.setTime(birthdayTimestamp);
+                    compulsoryEndDate.setFullYear(compulsoryEndDate.getFullYear() + 20);
+                    compulsoryEndDate.setMonth(11);
+                    compulsoryEndDate.setDate(31);
+                    table.setCellValue(event.row, endDateColumnIndex, compulsoryEndDate.getTime());
+                  }
+                }
+              }
             }
             else {
               table.hideCell(event.row, table.getNamedColumnIndex('message'));
@@ -745,7 +766,7 @@
               studyPeriods[i].type,
               studyPeriods[i].end,
               '',
-              '${compulsoryEducationEndDateMessage}'
+              ''
             ]);
           }
           studyPeriodsTable.addRows(studyPeriodRows);
@@ -1028,7 +1049,7 @@
                 <jsp:param name="titleLocale" value="students.editStudent.birthdayTitle"/>
                 <jsp:param name="helpLocale" value="students.editStudent.birthdayHelp"/>
               </jsp:include>            
-              <input type="text" name="birthday" class="ixDateField" value="${person.birthday.time}">
+              <input type="text" name="birthday" ix:datefieldid="birthday" class="ixDateField" value="${person.birthday.time}">
             </div>
       
             <div class="genericFormSection">     

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -6,6 +6,7 @@
 <%@ taglib uri="/ix" prefix="ix"%>
 <%@ page import="java.util.Calendar" %>
 <%@ page import="fi.otavanopisto.pyramus.domainmodel.base.Person" %>
+<%@ page import="fi.otavanopisto.pyramus.domainmodel.students.StudentStudyPeriod" %>
 <%@ page import="fi.otavanopisto.pyramus.domainmodel.students.StudentStudyPeriodType" %>
 <%@ page import="fi.otavanopisto.pyramus.domainmodel.users.Role" %>
 
@@ -3080,16 +3081,33 @@
                             <div>
                               <fmt:message key="generic.studentStudyPeriods.${period.periodType}"/>
                               <fmt:formatDate value="${period.begin}"/> - <fmt:formatDate value="${period.end}"/>
+                              
                               <c:if test="${period.periodType == StudentStudyPeriodType.COMPULSORY_EDUCATION && not empty compulsoryEducationEndDate}">
-                                <span style="color: gray; font-style: italic;">
-                                  <fmt:message key="students.viewStudent.studyPeriodCompulsoryEducationEndDate">
-                                    <fmt:param>
-                                      <fmt:formatDate value="${compulsoryEducationEndDate}"/>
-                                    </fmt:param>
-                                  </fmt:message>
-                                </span>
+                                <div class="genericFormSectionHelp" style="background-image: url(${pageContext.request.contextPath}/gfx/icons/16x16/apps/help-browser.png);">
+                                  <div class="genericFormSectionHelpText">
+                                    <fmt:message key="students.viewStudent.studyPeriodCompulsoryEducationEndDate">
+                                      <fmt:param>
+                                        <fmt:formatDate value="${compulsoryEducationEndDate}"/>
+                                      </fmt:param>
+                                    </fmt:message>
+                                  </div>
+                                </div>
                               </c:if>
                             </div>
+
+                            <!-- If COMPULSORY_EDUCATION has an end date, it automatically generates a new period NON_COMPULSORY_EDUCATION from the following day -->
+                            <c:if test="${period.periodType == StudentStudyPeriodType.COMPULSORY_EDUCATION && not empty period.end}">
+                              <%
+                                StudentStudyPeriod period = (StudentStudyPeriod) pageContext.getAttribute("period");
+                                Calendar cal = Calendar.getInstance();
+                                cal.setTime(period.getEnd());
+                                cal.add(Calendar.DAY_OF_MONTH, 1);
+                                pageContext.setAttribute("nextNonCompulsoryPeriodStart", cal.getTime());
+                              %>
+
+                              <fmt:message key="generic.studentStudyPeriods.NON_COMPULSORY_EDUCATION"/>
+                              <fmt:formatDate value="${nextNonCompulsoryPeriodStart}"/> -
+                            </c:if>
                           </c:forEach>
                         </div>
                       </div>


### PR DESCRIPTION
* Maksuttoman oppivelvollisuuden jaksolla voi nyt olla päättymispäivä
* Hakulomakkeen hyväksynnässä oppivelvollisen maksuttomuuden päättymispäivämäärän esitäyttö (sen vuoden loppu kun opiskelija 20v) ja opiskelijaksi viennissä ko. päivä asetetaan maksuttoman oppivelvollisuuden jakson päättymispäiväksi, ei enää omaksi jaksoksi
* Maksuttoman oppivelvollisuuden jakson päättymispäivästä muodostuu Koskeen uusi maksullinen jakso alkaen päättymispäivää seuraavasta päivästä
* Opiskelijan profiilissa näytetään tämä Koskeen automaattisesti muodostuva jakso
* Lisätty validointi, joka katsoo, että maksuttoman oppivelvollisuuden jaksolla pitää olla myös päättymispäivä (joko samalla jaksolla tai vanhalla ei maksuttoman oppivelvollisuuden piirissä -jaksolla)
