### PR TITLE
Maksuttomuuteen liittyvien opintojaksojen päättymispäivä saa olla opintojen päättymisen jälkeen

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentStudyPeriodType.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/students/StudentStudyPeriodType.java
@@ -10,9 +10,20 @@ public enum StudentStudyPeriodType {
   NON_COMPULSORY_EDUCATION,
   EXTENDED_COMPULSORY_EDUCATION;
 
+  /**
+   * Periods that only have a start date
+   */
   public static final EnumSet<StudentStudyPeriodType> BEGINDATE_ONLY = EnumSet.of(
       PROLONGED_STUDYENDDATE,
       NON_COMPULSORY_EDUCATION
+  );
+  
+  /**
+   * Period end date can be beyond Student's study end date
+   */
+  public static final EnumSet<StudentStudyPeriodType> ALLOW_PERIOD_END_OUTSIDE_STUDYTIME = EnumSet.of(
+      COMPULSORY_EDUCATION, 
+      EXTENDED_COMPULSORY_EDUCATION
   );
   
 }

--- a/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentTools.java
+++ b/pyramus/src/main/java/fi/otavanopisto/pyramus/views/students/ViewStudentTools.java
@@ -38,8 +38,13 @@ public class ViewStudentTools {
     StudentStudyPeriodDAO studentStudyPeriodDAO = DAOFactory.getInstance().getStudentStudyPeriodDAO();
     List<StudentStudyPeriod> studyPeriods = studentStudyPeriodDAO.listByStudent(student);
     for (StudentStudyPeriod studyPeriod : studyPeriods) {
-      if ((studyPeriod.getBegin() != null && !DateUtils.isWithin(studyPeriod.getBegin(), student.getStudyStartDate(), student.getStudyEndDate())) ||
-          (studyPeriod.getEnd() != null && !DateUtils.isWithin(studyPeriod.getEnd(), student.getStudyStartDate(), student.getStudyEndDate()))) {
+      boolean studyPeriodOutsideStudyTime = studyPeriod.getBegin() != null && !DateUtils.isWithin(studyPeriod.getBegin(), student.getStudyStartDate(), student.getStudyEndDate());
+      
+      if (!studyPeriodOutsideStudyTime && studyPeriod.getEnd() != null && !StudentStudyPeriodType.ALLOW_PERIOD_END_OUTSIDE_STUDYTIME.contains(studyPeriod.getPeriodType())) {
+        studyPeriodOutsideStudyTime = studyPeriod.getEnd() != null && !DateUtils.isWithin(studyPeriod.getEnd(), student.getStudyStartDate(), student.getStudyEndDate());
+      }
+      
+      if (studyPeriodOutsideStudyTime) {
         warnings.add(new ViewStudentValidationWarning(student, ViewStudentValidationType.STUDYPERIOD_OUTSIDE_STUDYTIME,
             ViewStudentValidationWarningSeverity.ERROR));
       }


### PR DESCRIPTION
Maksuttomuuteen liityvät opintojaksot eivät enää aiheuta validointivirhettä, mikäli niiden päättymispäivä on opintojen päättymisen jälkeen. Koskelle kelpaa nämä useimmissa tapauksissa ja maksuttomuus-jakson päättyessä Koski-integraatiossa tiputetaan päättymispäivää seuraava maksullinen-jakson alkamispäivä automaattisesti pois, jos se on opintojen päättymisen jälkeen.

Closes #1790 