### PR TITLE
Perusopetuksen raportin säätöjä osa 3

### DIFF
--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/CourseAssessmentDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/CourseAssessmentDAO.java
@@ -351,7 +351,8 @@ public class CourseAssessmentDAO extends PyramusEntityDAO<CourseAssessment> {
 
   /**
    * Lists CourseAssessments that have a date between the given dates and 
-   * belong to students that are in the specified study programmes.
+   * belong to students that are in the specified study programmes. The
+   * assessment and the student must not be archived.
    * 
    * Used for reporting, handle with care.
    */
@@ -369,6 +370,7 @@ public class CourseAssessmentDAO extends PyramusEntityDAO<CourseAssessment> {
         criteriaBuilder.and(
             studentJoin.get(Student_.studyProgramme).in(studyProgrammes),
             criteriaBuilder.between(root.get(CourseAssessment_.date), begin, end),
+            criteriaBuilder.equal(studentJoin.get(Student_.archived), Boolean.FALSE),
             criteriaBuilder.equal(root.get(CourseAssessment_.archived), Boolean.FALSE)
         )
     );

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/TransferCreditDAO.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/dao/grading/TransferCreditDAO.java
@@ -1,6 +1,7 @@
 package fi.otavanopisto.pyramus.dao.grading;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -10,6 +11,7 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
@@ -19,12 +21,14 @@ import fi.otavanopisto.pyramus.domainmodel.base.Curriculum;
 import fi.otavanopisto.pyramus.domainmodel.base.EducationalLength;
 import fi.otavanopisto.pyramus.domainmodel.base.EducationalTimeUnit;
 import fi.otavanopisto.pyramus.domainmodel.base.School;
+import fi.otavanopisto.pyramus.domainmodel.base.StudyProgramme;
 import fi.otavanopisto.pyramus.domainmodel.base.Subject;
 import fi.otavanopisto.pyramus.domainmodel.grading.Grade;
 import fi.otavanopisto.pyramus.domainmodel.grading.TransferCredit;
 import fi.otavanopisto.pyramus.domainmodel.grading.TransferCreditFunding;
 import fi.otavanopisto.pyramus.domainmodel.grading.TransferCredit_;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
+import fi.otavanopisto.pyramus.domainmodel.students.Student_;
 import fi.otavanopisto.pyramus.domainmodel.users.StaffMember;
 import fi.otavanopisto.pyramus.events.TransferCreditEvent;
 import fi.otavanopisto.pyramus.events.types.Created;
@@ -268,6 +272,40 @@ public class TransferCreditDAO extends PyramusEntityDAO<TransferCredit> {
     predicates.add(criteriaBuilder.equal(root.get(TransferCredit_.student), student));
 
     criteria.where(criteriaBuilder.and(predicates.toArray(new Predicate[0])));
+    
+    return entityManager.createQuery(criteria).getResultList();
+  }
+
+  /**
+   * Used for reporting, handle with care
+   * 
+   * @param studyProgrammes
+   * @param begin
+   * @param end
+   * @param funding
+   * @return
+   */
+  public List<TransferCredit> listByStudyProgrammesAndDatesAndFunding(Collection<StudyProgramme> studyProgrammes, Date begin,
+      Date end, TransferCreditFunding funding) {
+    EntityManager entityManager = getEntityManager(); 
+    
+    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<TransferCredit> criteria = criteriaBuilder.createQuery(TransferCredit.class);
+    Root<TransferCredit> root = criteria.from(TransferCredit.class);
+    Join<TransferCredit, Student> studentJoin = root.join(TransferCredit_.student);
+    criteria.select(root);
+
+    criteria.where(
+        criteriaBuilder.and(
+            studentJoin.get(Student_.studyProgramme).in(studyProgrammes),
+            criteriaBuilder.between(root.get(TransferCredit_.date), begin, end),
+            criteriaBuilder.equal(root.get(TransferCredit_.funding), funding),
+            criteriaBuilder.equal(studentJoin.get(Student_.archived), Boolean.FALSE),
+            criteriaBuilder.equal(root.get(TransferCredit_.archived), Boolean.FALSE)
+        )
+    );
+    
+    criteria.orderBy(criteriaBuilder.asc(root.get(TransferCredit_.date)));
     
     return entityManager.createQuery(criteria).getResultList();
   }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseAssessment.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseAssessment.java
@@ -9,10 +9,13 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.otavanopisto.pyramus.domainmodel.base.CourseModule;
 import fi.otavanopisto.pyramus.domainmodel.base.Curriculum;
 import fi.otavanopisto.pyramus.domainmodel.base.EducationalLength;
 import fi.otavanopisto.pyramus.domainmodel.base.Subject;
+import fi.otavanopisto.pyramus.domainmodel.courses.Course;
 import fi.otavanopisto.pyramus.domainmodel.courses.CourseStudent;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
 
@@ -48,7 +51,14 @@ public class CourseAssessment extends CourseCredit {
   @Override
   @Transient
   public String getCourseName() {
-    return getCourseModule() != null && getCourseModule().getCourse() != null ? getCourseModule().getCourse().getName() : null;
+    if (getCourseStudent() != null && getCourseStudent().getCourse() != null) {
+      Course course = getCourseStudent().getCourse();
+      
+      if (StringUtils.isNotBlank(course.getName())) {
+        return StringUtils.isBlank(course.getNameExtension()) ? course.getName() : String.format("%s (%s)", course.getName(), course.getNameExtension());
+      }
+    }
+    return null;
   }
 
   @Override

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseAssessment.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseAssessment.java
@@ -1,5 +1,7 @@
 package fi.otavanopisto.pyramus.domainmodel.grading;
 
+import java.util.Set;
+
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -8,6 +10,7 @@ import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
 import fi.otavanopisto.pyramus.domainmodel.base.CourseModule;
+import fi.otavanopisto.pyramus.domainmodel.base.Curriculum;
 import fi.otavanopisto.pyramus.domainmodel.base.EducationalLength;
 import fi.otavanopisto.pyramus.domainmodel.base.Subject;
 import fi.otavanopisto.pyramus.domainmodel.courses.CourseStudent;
@@ -15,7 +18,7 @@ import fi.otavanopisto.pyramus.domainmodel.students.Student;
 
 @Entity
 @PrimaryKeyJoinColumn(name="id")
-public class CourseAssessment extends Credit {
+public class CourseAssessment extends CourseCredit {
   
   public CourseAssessment() {
     super();
@@ -40,6 +43,18 @@ public class CourseAssessment extends Credit {
   @Transient
   public EducationalLength getCourseLength() {
     return getCourseModule() != null ? getCourseModule().getCourseLength() : null; 
+  }
+  
+  @Override
+  @Transient
+  public String getCourseName() {
+    return getCourseModule() != null && getCourseModule().getCourse() != null ? getCourseModule().getCourse().getName() : null;
+  }
+
+  @Override
+  @Transient
+  public Set<Curriculum> getCurriculums() {
+    return getCourseModule() != null && getCourseModule().getCourse() != null && getCourseModule().getCourse().getCurriculums() != null ? getCourseModule().getCourse().getCurriculums() : Set.of();
   }
   
   public void setCourseStudent(CourseStudent courseStudent) {
@@ -67,5 +82,5 @@ public class CourseAssessment extends Credit {
   @ManyToOne
   @JoinColumn(name="courseModule", nullable = false)
   private CourseModule courseModule;
-  
+
 }

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseCredit.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/CourseCredit.java
@@ -1,0 +1,51 @@
+package fi.otavanopisto.pyramus.domainmodel.grading;
+
+import java.util.Set;
+
+import fi.otavanopisto.pyramus.domainmodel.base.Curriculum;
+import fi.otavanopisto.pyramus.domainmodel.base.EducationalLength;
+import fi.otavanopisto.pyramus.domainmodel.base.Subject;
+
+/**
+ * Abstraction layer for Credits that are Student's
+ * completion marks of a Course or Course Module.
+ * 
+ * Abstracts the set of properties there are common
+ * for these types of Credits such that those types
+ * can be handled with common methods.
+ */
+public abstract class CourseCredit extends Credit {
+
+  /**
+   * Returns the Course name.
+   * @return
+   */
+  public abstract String getCourseName();
+  
+  /**
+   * Returns the Subject of the Credit.
+   * @return
+   */
+  public abstract Subject getSubject();
+  
+  /**
+   * Returns the Course Number of the Credit.
+   * @return
+   */
+  public abstract Integer getCourseNumber();
+
+  /**
+   * Returns the Course Length of the Credit.
+   * @return
+   */
+  public abstract EducationalLength getCourseLength();
+  
+  /**
+   * Returns curriculum(s) this credit applies to. 
+   * Returns empty set if there is no curriculums,
+   * which should be interpreted as the credit applying
+   * to any and all curriculums.
+   * @return
+   */
+  public abstract Set<Curriculum> getCurriculums();
+}

--- a/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/TransferCredit.java
+++ b/persistence/src/main/java/fi/otavanopisto/pyramus/domainmodel/grading/TransferCredit.java
@@ -1,5 +1,7 @@
 package fi.otavanopisto.pyramus.domainmodel.grading;
 
+import java.util.Set;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -9,6 +11,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -21,11 +24,17 @@ import fi.otavanopisto.pyramus.domainmodel.students.Student;
 
 @Entity
 @PrimaryKeyJoinColumn(name = "id")
-public class TransferCredit extends Credit {
+public class TransferCredit extends CourseCredit {
 
   public TransferCredit() {
     super();
     setCreditType(CreditType.TransferCredit);
+  }
+
+  @Override
+  @Transient
+  public Set<Curriculum> getCurriculums() {
+    return this.curriculum != null ? Set.of(this.curriculum) : Set.of();
   }
 
   public String getCourseName() {
@@ -145,4 +154,5 @@ public class TransferCredit extends Credit {
   @NotNull
   @Column(nullable = false)
   private Boolean offCurriculum;
+
 }

--- a/pyramus/src/main/webapp/templates/reports/programmatic/perusopetus.jsp
+++ b/pyramus/src/main/webapp/templates/reports/programmatic/perusopetus.jsp
@@ -17,6 +17,45 @@
     <jsp:include page="/templates/generic/validation_support.jsp"></jsp:include>
     
     <script type="text/javascript">
+      const CREDITROW_STATES = {
+        "ACCEPTED": {
+          "title": "Hyväksytty"
+        },
+        "RAISED": {
+          "title": "Korotettu"
+        },
+        "RAISED_SAMEYEAR": {
+          "title": "Korotettu samana kalenterivuonna"
+        },
+        "RAISED_PASSING": {
+          "title": "Korotettu hyväksyttyä arvosanaa"
+        },
+        "RAISED_SAMEYEAR_PASSING": {
+          "title": "Korotettu hyväksyttyä arvosanaa samana vuonna"
+        },
+        "REJECTED_GRADE": {
+          "title": "Ei-sallittu arvosana"
+        },
+        "REJECTED_EDUCATIONTYPE": {
+          "title": "Kurssin ja opiskelijan koulutusasteet ei vastaa"
+        },
+        "REJECTED_COURSELENGTH": {
+          "title": "Kurssin laajuus virheelinen"
+        },
+        "REJECTED_MISMATCHING_CURRICULUM": {
+          "title": "Kurssin ja opiskelijan ops:t ei vastaa"
+        },
+        "REJECTED_MISSING_STUDENT_CURRICULUM": {
+          "title": "Opiskelijalta puuttuu ops"
+        }
+      };
+      const CREDITTYPE_TRANSLATIONS = {
+        "CA": "Kurssiarviointi",
+        "L-CA": "Siirretty kurssiarviointi",
+        "TC": "Hyväksiluku",
+        "L-TC": "Siirretty hyväksiluku"
+      };
+    
       function submitForm() {
         var glassPane = new IxGlassPane(document.body, { });
         glassPane.show();
@@ -24,14 +63,14 @@
         // Use {{ variable }} syntax
         var syntax = /(^|.|\r|\n)(\{{\s*([A-Za-z0-9_öåäÖÅÄ]+)\s*}})/;
         var creditRowTemplate = new Template(
-            '<td>{{courseName}}</td>' +
+            '<td><a href="/courses/viewcourse.page?course={{courseId}}" target="_blank">{{courseName}}</a></td>' +
             '<td>{{courseCode}}</td>' +
             '<td>{{courseLengthUI}}</td>' +
             '<td>{{creditDateUI}}</td>' +
             '<td>{{gradeName}}</td>' +
             '<td>{{gradingScaleName}}</td>' +
             '<td>{{groupCourseUI}}</td>' +
-            '<td>{{studentName}}</td>' +
+            '<td><a href="/students/viewstudent.page?person={{personId}}" target="_blank">{{studentName}}</a></td>' +
             '<td>{{studyProgrammeName}}</td>' +
             '<td>{{assessorName}}</td>' +
             '<td>{{schoolName}}</td>' +
@@ -40,7 +79,8 @@
             '<td>{{mismatchingCurriculumUI}}</td>' +
             '<td>{{otherFundingUI}}</td>' +
             '<td>{{evaluatedOutsideStudiesUI}}</td>' +
-            '<td>{{koskiFailureUI}}</td>', syntax);
+            '<td>{{koskiFailureUI}}</td>' +
+            '<td>{{stateUI}}</td>', syntax);
 
         var summaryRowTemplate = new Template(
             '<th align="left">{{rowName}}</th>' +
@@ -61,6 +101,7 @@
           .then(function (response) {
             const acceptedCreditsElement = $('acceptedCredits');
             const rejectedCreditsElement = $('rejectedCredits');
+            const fundedTransferCreditsElement = $('fundedTransferCreditsElement');
             const summaryElement = $('summary');
 
             document.querySelectorAll('.perusopetus_preport_tr').forEach(element => element.remove());
@@ -85,10 +126,29 @@
               }
             }
 
+            if (data.fundedTransferCredits) {
+              for (const credit of data.fundedTransferCredits) {
+                const cells = creditRowTemplate.evaluate(prepareCreditRow(credit));
+                const tr = new Element("tr", { className: "perusopetus_preport_tr" });
+                tr.update(cells);
+                fundedTransferCreditsElement.appendChild(tr);
+              }
+            }
+            
             if (data.summary) {
               const summaryRows = [
                 {
-                  rowName: "Lukumäärä",
+                  rowName: "Yhteensä (kurssiarvioinnit + vos-hyv.luk)",
+                  accepted: (data.summary.acceptedCreditCount || 0) + (data.summary.acceptedTransferCreditCount || 0),
+                  rejected: (data.summary.rejectedCreditCount || 0) + (data.summary.rejectedTransferCreditCount || 0)
+                },
+                {
+                  rowName: "VOS-hyväksilukujen lukumäärä",
+                  accepted: data.summary.acceptedTransferCreditCount || 0,
+                  rejected: data.summary.rejectedTransferCreditCount || 0
+                },
+                {
+                  rowName: "Kursiarviointien lukumäärä",
                   accepted: data.summary.acceptedCreditCount || 0,
                   rejected: data.summary.rejectedCreditCount || 0
                 },
@@ -101,49 +161,19 @@
                   rowName: "Kurssin pituus opintopisteissä",
                   accepted: data.summary.acceptedByLengthUnit["op"] || 0,
                   rejected: data.summary.rejectedByLengthUnit["op"] || 0
-                },
-                {
-                  rowName: "Tila: Hyväksytty",
-                  accepted: data.summary.acceptedByState["ACCEPTED"] || 0,
-                  rejected: data.summary.rejectedByState["ACCEPTED"] || 0
-                },
-                {
-                  rowName: "Tila: Korotettu",
-                  accepted: data.summary.acceptedByState["RAISED"] || 0,
-                  rejected: data.summary.rejectedByState["RAISED"] || 0
-                },
-                {
-                  rowName: "Tila: Korotettu samana kalenterivuonna",
-                  accepted: data.summary.acceptedByState["RAISED_SAMEYEAR"] || 0,
-                  rejected: data.summary.rejectedByState["RAISED_SAMEYEAR"] || 0
-                },
-                {
-                  rowName: "Tila: Korotettu hyväksyttyä arvosanaa",
-                  accepted: data.summary.acceptedByState["RAISED_PASSING"] || 0,
-                  rejected: data.summary.rejectedByState["RAISED_PASSING"] || 0
-                },
-                {
-                  rowName: "Tila: Korotettu hyväksyttyä arvosanaa samana vuonna",
-                  accepted: data.summary.acceptedByState["RAISED_SAMEYEAR_PASSING"] || 0,
-                  rejected: data.summary.rejectedByState["RAISED_SAMEYEAR_PASSING"] || 0
-                },
-                {
-                  rowName: "Tila: Poistettu, arvosana",
-                  accepted: data.summary.acceptedByState["REJECTED_GRADE"] || 0,
-                  rejected: data.summary.rejectedByState["REJECTED_GRADE"] || 0
-                },
-                {
-                  rowName: "Tila: Poistettu, koulutusaste",
-                  accepted: data.summary.acceptedByState["REJECTED_EDUCATIONTYPE"] || 0,
-                  rejected: data.summary.rejectedByState["REJECTED_EDUCATIONTYPE"] || 0
-                },
-                {
-                  rowName: "Tila: Poistettu, kurssin laajuus",
-                  accepted: data.summary.acceptedByState["REJECTED_COURSELENGTH"] || 0,
-                  rejected: data.summary.rejectedByState["REJECTED_COURSELENGTH"] || 0
                 }
               ];
-
+              
+              const stateKeys = Object.keys(CREDITROW_STATES);
+              for (const stateKey of stateKeys) {
+                const state = CREDITROW_STATES[stateKey];
+                summaryRows.push({
+                  rowName: "Tila: " + state.title,
+                  accepted: data.summary.acceptedByState[stateKey] || 0,
+                  rejected: data.summary.rejectedByState[stateKey] || 0
+                });
+              }
+              
               for (const summaryRow of summaryRows) {
                 const cells = summaryRowTemplate.evaluate(summaryRow);
                 const tr = new Element("tr", { className: "perusopetus_preport_tr" });
@@ -181,6 +211,9 @@
               previousEvaluationsTooltipUI += "\n";
             }
             
+            if (previousEvaluation.type && CREDITTYPE_TRANSLATIONS[previousEvaluation.type]) {
+              previousEvaluationsTooltipUI += CREDITTYPE_TRANSLATIONS[previousEvaluation.type] + ": ";
+            }
             previousEvaluationsTooltipUI += creditDateStr + " - " + previousEvaluation.gradeName;
           }
         }
@@ -193,6 +226,14 @@
           }
         }
         
+        var stateUI = "";
+        if (creditRow.state) {
+          const state = CREDITROW_STATES[creditRow.state];
+          if (state) {
+            stateUI = state.title;
+          }
+        }
+        
         return Object.assign(creditRow, {
           creditDateUI: dateStr,
           courseLengthUI: courseLengthUI,
@@ -202,7 +243,8 @@
           mismatchingCurriculumUI: creditRow.mismatchingCurriculum ? "3" : "",
           otherFundingUI: creditRow.otherFunding ? "4" : "",
           evaluatedOutsideStudiesUI: creditRow.evaluatedOutsideStudies ? "5" : "",
-          koskiFailureUI: creditRow.koskiFailure ? "Koski!" : ""
+          koskiFailureUI: creditRow.koskiFailure ? "Koski!" : "",
+          stateUI: stateUI
         });
       }
       
@@ -298,6 +340,7 @@
                 <th>Muu rah.(4)</th>
                 <th>Arviointi pvm (5)</th>
                 <th>Koski(6)</th>
+                <th>Tila</th>
               </tr>
             </table>
 
@@ -322,6 +365,32 @@
                 <th>Muu rah.(4)</th>
                 <th>Arviointi pvm (5)</th>
                 <th>Koski(6)</th>
+                <th>Tila</th>
+              </tr>
+            </table>
+            
+            <h1>VOS-rahoitukseen merkityt hyväksiluvut</h1>
+            <table id="fundedTransferCreditsElement" class="tableWithRowHighlighting">
+              <tr style="text-align: left;">
+                <th>Kurssi</th>
+                <th>Koodi</th>
+                <th>Pituus</th>
+                <th>Arviointipvm</th>
+                <th>Arvosana</th>
+                <th>Arvosana-asteikko</th>
+                <th>Ryhmäkurssi</th>
+                <th>Opiskelija</th>
+                <th>Koulutusohjelma</th>
+                <th>Opettaja</th>
+                <th>Oppilaitos</th>
+                <th>Oppilaitos k.ala</th>
+<!--                 <th>S.K-hyvluk(1)</th> -->
+                <th>Korotus (2)</th>
+                <th>Eri OPS(3)</th>
+                <th>Muu rah.(4)</th>
+                <th>Arviointi pvm (5)</th>
+                <th>Koski(6)</th>
+                <th>Tila</th>
               </tr>
             </table>
           </div>

--- a/pyramus/src/main/webapp/templates/students/viewstudent.jsp
+++ b/pyramus/src/main/webapp/templates/students/viewstudent.jsp
@@ -1442,7 +1442,7 @@
             Object.assign(studentParent, staticProps);
             
             const cells = studentParentRowTemplate.evaluate(studentParent);
-            const tr = new Element("tr", { className: "perusopetus_preport_tr", height: "26px", "data-studentParentChildId": studentParent.childId });
+            const tr = new Element("tr", { height: "26px", "data-studentParentChildId": studentParent.childId });
             tr.update(cells);
             studentParentInvitationsTableElement.appendChild(tr);
           }
@@ -1571,7 +1571,7 @@
             Object.assign(studentParent, staticProps);
             
             const cells = studentParentInvitationRowTemplate.evaluate(studentParent);
-            const tr = new Element("tr", { className: "perusopetus_preport_tr", height: "26px", "data-studentParentInvitationId": studentParent.invitationId });
+            const tr = new Element("tr", { height: "26px", "data-studentParentInvitationId": studentParent.invitationId });
             tr.update(cells);
             studentParentInvitationsTableElement.appendChild(tr);
           }

--- a/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/report/PerusopetusCredit.java
+++ b/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/report/PerusopetusCredit.java
@@ -178,6 +178,23 @@ public class PerusopetusCredit {
     this.courseLengthSymbol = courseLengthSymbol;
   }
 
+  public Long getCourseId() {
+    return courseId;
+  }
+
+  public void setCourseId(Long courseId) {
+    this.courseId = courseId;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  private Long courseId;
   private String courseName;
   private String courseCode;
   private Double courseLength;
@@ -193,6 +210,7 @@ public class PerusopetusCredit {
   private String assessorName;
   private String schoolName;
   private String schoolField;
+  private String type;
   
   private PerusopetusCreditState state;
   private boolean mismatchingCurriculum;

--- a/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/report/PerusopetusCreditReport.java
+++ b/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/report/PerusopetusCreditReport.java
@@ -27,6 +27,14 @@ public class PerusopetusCreditReport {
     return summary;
   }
 
+  public void addFundedTransferCredit(PerusopetusCredit credit) {
+    fundedTransferCredits.add(credit);
+  }
+  
+  public List<PerusopetusCredit> getFundedTransferCredits() {
+    return fundedTransferCredits;
+  }
+
   public class PerusopetusCreditReportSummary {
     
     public int getAcceptedCreditCount() {
@@ -43,6 +51,30 @@ public class PerusopetusCreditReport {
     
     public void incrementRejectedCreditCount() {
       this.rejectedCreditCount++;
+    }
+
+    public int getAcceptedTransferCreditCount() {
+      return acceptedTransferCreditCount;
+    }
+
+    public void incrementAcceptedTransferCreditCount() {
+      this.acceptedTransferCreditCount++;
+    }
+    
+    public void setAcceptedTransferCreditCount(int acceptedTransferCreditCount) {
+      this.acceptedTransferCreditCount = acceptedTransferCreditCount;
+    }
+
+    public int getRejectedTransferCreditCount() {
+      return rejectedTransferCreditCount;
+    }
+
+    public void incrementRejectedTransferCreditCount() {
+      this.rejectedTransferCreditCount++;
+    }
+
+    public void setRejectedTransferCreditCount(int rejectedTransferCreditCount) {
+      this.rejectedTransferCreditCount = rejectedTransferCreditCount;
     }
 
     public Map<String, Integer> getAcceptedByLengthUnit() {
@@ -103,6 +135,8 @@ public class PerusopetusCreditReport {
 
     private int acceptedCreditCount;
     private int rejectedCreditCount;
+    private int acceptedTransferCreditCount;
+    private int rejectedTransferCreditCount;
     private Map<String, Integer> acceptedByLengthUnit = new HashMap<>();
     private Map<String, Integer> rejectedByLengthUnit = new HashMap<>();
     private Map<PerusopetusCreditState, Integer> acceptedByState = new HashMap<>();
@@ -112,4 +146,5 @@ public class PerusopetusCreditReport {
   private final PerusopetusCreditReportSummary summary = new PerusopetusCreditReportSummary();
   private final List<PerusopetusCredit> acceptedCredits = new ArrayList<>();
   private final List<PerusopetusCredit> rejectedCredits = new ArrayList<>();
+  private final List<PerusopetusCredit> fundedTransferCredits = new ArrayList<>();
 }

--- a/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/report/PerusopetusCreditState.java
+++ b/rest-model/src/main/java/fi/otavanopisto/pyramus/rest/model/report/PerusopetusCreditState.java
@@ -18,7 +18,11 @@ public enum PerusopetusCreditState {
   // Rejected due to mismatch or absence of course length
   REJECTED_COURSELENGTH,
   // Rejected due to invalid grade
-  REJECTED_GRADE;
+  REJECTED_GRADE,
+  // Rejected, student's curriculum doesn't match credit's curriculum
+  REJECTED_MISMATCHING_CURRICULUM,
+  // Rejected, student has no curriculum
+  REJECTED_MISSING_STUDENT_CURRICULUM;
   
   
   public boolean isAcceptedState() {

--- a/rest/src/main/java/fi/otavanopisto/pyramus/rest/ReportRESTService.java
+++ b/rest/src/main/java/fi/otavanopisto/pyramus/rest/ReportRESTService.java
@@ -32,9 +32,12 @@ import fi.otavanopisto.pyramus.domainmodel.base.StudyProgramme;
 import fi.otavanopisto.pyramus.domainmodel.base.Subject;
 import fi.otavanopisto.pyramus.domainmodel.courses.Course;
 import fi.otavanopisto.pyramus.domainmodel.grading.CourseAssessment;
+import fi.otavanopisto.pyramus.domainmodel.grading.CourseCredit;
 import fi.otavanopisto.pyramus.domainmodel.grading.Credit;
 import fi.otavanopisto.pyramus.domainmodel.grading.CreditLink;
+import fi.otavanopisto.pyramus.domainmodel.grading.CreditType;
 import fi.otavanopisto.pyramus.domainmodel.grading.TransferCredit;
+import fi.otavanopisto.pyramus.domainmodel.grading.TransferCreditFunding;
 import fi.otavanopisto.pyramus.domainmodel.students.Student;
 import fi.otavanopisto.pyramus.domainmodel.students.StudentFunding;
 import fi.otavanopisto.pyramus.framework.DateUtils;
@@ -116,7 +119,7 @@ public class ReportRESTService extends AbstractRESTService {
     List<CourseAssessment> assessments = courseAssessmentDAO.listByStudyProgrammesAndDates(studyProgrammes, beginDate, endDate);
     
     for (CourseAssessment assessment : assessments) {
-      PerusopetusCredit restCredit = restCredit(assessment, educationTypeCode);
+      PerusopetusCredit restCredit = restCreditForCourseAssessment(assessment, educationTypeCode);
       
       if (restCredit.getState() != null && restCredit.getState().isAcceptedState()) {
         report.addAcceptedCredit(restCredit);
@@ -124,6 +127,22 @@ public class ReportRESTService extends AbstractRESTService {
       else {
         report.addRejectedCredit(restCredit);
       }
+    }
+    
+    // VOS-hyväksiluvut
+    
+    List<TransferCredit> vosTCs = transferCreditDAO.listByStudyProgrammesAndDatesAndFunding(studyProgrammes, beginDate, endDate, TransferCreditFunding.GOVERNMENT_FUNDING);
+    for (TransferCredit transferCredit : vosTCs) {
+      PerusopetusCredit restCredit = restCredit(transferCredit, educationTypeCode);
+      
+      if (restCredit.getState() != null && restCredit.getState().isAcceptedState()) {
+        report.getSummary().incrementAcceptedTransferCreditCount();
+      }
+      else {
+        report.getSummary().incrementRejectedTransferCreditCount();
+      }
+      
+      report.addFundedTransferCredit(restCredit);
     }
     
     // Summary
@@ -155,10 +174,10 @@ public class ReportRESTService extends AbstractRESTService {
     return Response.ok(report).build();
   }
   
-  private PerusopetusCreditState handleCreditList(List<? extends Credit> creditList, boolean creditsAreCourseAssessments, CourseAssessment assessment, PerusopetusCreditState state, List<PerusopetusCredit> previousEvaluations) {
+  private PerusopetusCreditState handleCreditList(List<? extends Credit> creditList, boolean creditsAreCourseAssessments, boolean creditsAreLinks, CourseCredit assessment, PerusopetusCreditState state, List<PerusopetusCredit> previousEvaluations) {
     for (Credit matchingAssessment : creditList) {
       // Skippaa jos credit.id on sama (ts sama Credit löytyy listasta)
-      if (!matchingAssessment.getId().equals(assessment.getId())) {
+      if (matchingAssessment.getId().equals(assessment.getId())) {
         continue;
       }
       
@@ -171,9 +190,13 @@ public class ReportRESTService extends AbstractRESTService {
       // Jos matchingAssessment on annettu ennen arviointia, on kyseessä jonkunsortin korotus
       if (matchingAssessment.getDate().before(assessment.getDate())) {
         // Pelkät perustiedot aiemmista suorituksista
+        String creditType = matchingAssessment.getCreditType() == CreditType.CourseAssessment ? (creditsAreLinks ? "L-CA" : "CA")
+            : matchingAssessment.getCreditType() == CreditType.TransferCredit ? (creditsAreLinks ? "L-TC" : "TC") : null;
+
         PerusopetusCredit previousEvaluation = new PerusopetusCredit();
         previousEvaluation.setGradeDate(matchingAssessment.getDate());
         previousEvaluation.setGradeName(gradeName);
+        previousEvaluation.setType(creditType);
         previousEvaluations.add(previousEvaluation);
         
         // Samasta kurssista saa rahoitusta vain kerran kalenterivuodessa
@@ -193,55 +216,49 @@ public class ReportRESTService extends AbstractRESTService {
     return state;
   }
   
-  
-  private PerusopetusCredit restCredit(CourseAssessment courseAssessment, String educationTypeCode) {
-    Student student = courseAssessment.getStudent();
-    Subject subject = courseAssessment.getSubject();
-    Integer courseNumber = courseAssessment.getCourseNumber();
-    String studentName = String.format("%s, %s", student.getLastName(), student.getFirstName());
-    
-    CourseModule courseModule = courseAssessment.getCourseModule();
-    CourseBase courseBase = courseModule.getCourse();
 
+  private PerusopetusCredit restCredit(CourseCredit courseCredit, String educationTypeCode) {
+    Student student = courseCredit.getStudent();
+    Subject subject = courseCredit.getSubject();
+    Integer courseNumber = courseCredit.getCourseNumber();
+    String studentName = String.format("%s, %s", student.getLastName(), student.getFirstName());
+    String creditType = courseCredit.getCreditType() == CreditType.CourseAssessment ? "CA"
+        : courseCredit.getCreditType() == CreditType.TransferCredit ? "TC" : null;
+    
     PerusopetusCreditState state = PerusopetusCreditState.ACCEPTED;
     boolean otherFunding = student.getFunding() == StudentFunding.OTHER_FUNDING;
     
     String courseCode;
-    if (courseAssessment.getSubject() != null && StringUtils.isNotBlank(courseAssessment.getSubject().getCode())) {
-      courseCode = courseAssessment.getSubject().getCode();
-      if (courseAssessment.getCourseNumber() != null) {
-        courseCode += courseAssessment.getCourseNumber();
+    if (courseCredit.getSubject() != null && StringUtils.isNotBlank(courseCredit.getSubject().getCode())) {
+      courseCode = courseCredit.getSubject().getCode();
+      if (courseCredit.getCourseNumber() != null) {
+        courseCode += courseCredit.getCourseNumber();
       }
     }
     else {
       courseCode = null;
     }
     
-    boolean groupCourse;
-    if (courseBase instanceof Course && ((Course) courseBase).getTags() != null) {
-      Course course = (Course) courseBase;
-      groupCourse = course.getTags().stream().anyMatch(tag -> StringUtils.equals(tag.getText(), "ryhmäkurssi"));
-    }
-    else {
-      groupCourse = false;
-    }
-
     Double courseLength = null;
     String courseLengthSymbol = null;
-    if (courseModule.getCourseLength() != null && courseModule.getCourseLength().getUnits() != null && courseModule.getCourseLength().getUnit() != null && StringUtils.isNotBlank(courseModule.getCourseLength().getUnit().getSymbol())) {
-      courseLength = courseModule.getCourseLength().getUnits();
-      courseLengthSymbol = courseModule.getCourseLength().getUnit().getSymbol();
+    if (courseCredit.getCourseLength() != null && courseCredit.getCourseLength().getUnits() != null && courseCredit.getCourseLength().getUnit() != null && StringUtils.isNotBlank(courseCredit.getCourseLength().getUnit().getSymbol())) {
+      courseLength = courseCredit.getCourseLength().getUnits();
+      courseLengthSymbol = courseCredit.getCourseLength().getUnit().getSymbol();
     }
 
     boolean mismatchingCurriculum;
-    if (CollectionUtils.isNotEmpty(courseBase.getCurriculums())) {
+    if (CollectionUtils.isNotEmpty(courseCredit.getCurriculums())) {
       if (student.getCurriculum() != null) {
-        mismatchingCurriculum = !courseBase.getCurriculums().stream().anyMatch(courseCurriculum -> courseCurriculum.getId().equals(student.getCurriculum().getId()));
+        mismatchingCurriculum = !courseCredit.getCurriculums().stream().anyMatch(courseCurriculum -> courseCurriculum.getId().equals(student.getCurriculum().getId()));
+        if (mismatchingCurriculum) {
+          state = PerusopetusCreditState.REJECTED_MISMATCHING_CURRICULUM;
+        }
       }
       else {
         // This could be communicated in a different manner, but student 
         // having no curriculum is a problem in this context.
         mismatchingCurriculum = true;
+        state = PerusopetusCreditState.REJECTED_MISSING_STUDENT_CURRICULUM;
       }
     }
     else {
@@ -249,60 +266,59 @@ public class ReportRESTService extends AbstractRESTService {
       mismatchingCurriculum = false;
     }
 
-    boolean evaluatedOutsideStudies = student.getStudyStartDate() == null || courseAssessment.getDate() == null || courseAssessment.getDate().before(student.getStudyStartDate());
+    boolean evaluatedOutsideStudies = student.getStudyStartDate() == null || courseCredit.getDate() == null || courseCredit.getDate().before(student.getStudyStartDate());
     if (!evaluatedOutsideStudies && student.getStudyEndDate() != null) {
-      evaluatedOutsideStudies = courseAssessment.getDate().after(DateUtils.endOfDay(student.getStudyEndDate()));
+      evaluatedOutsideStudies = courseCredit.getDate().after(DateUtils.endOfDay(student.getStudyEndDate()));
     }
     
     boolean koskiFailure = !koskiController.isSuccessfullyUpdated(student.getPerson());
 
     // 0h-suoritukset poistetaan
-    if (courseAssessment.getCourseLength() == null || courseAssessment.getCourseLength().getUnits() == null || courseAssessment.getCourseLength().getUnits() == 0) {
+    if (courseCredit.getCourseLength() == null || courseCredit.getCourseLength().getUnits() == null || courseCredit.getCourseLength().getUnits() == 0) {
       state = PerusopetusCreditState.REJECTED_COURSELENGTH;
     }
     
     // K-arvosanat (= kaikki ei-sallitut arvosanat) pois
-    String gradeName = courseAssessment.getGrade() != null ? courseAssessment.getGrade().getName() : null;
+    String gradeName = courseCredit.getGrade() != null ? courseCredit.getGrade().getName() : null;
     if (gradeName == null || !PyramusConsts.Perusopetus.ALLOWED_GRADES.contains(gradeName)) {
       state = PerusopetusCreditState.REJECTED_GRADE;
     }
     
     List<PerusopetusCredit> previousEvaluations = new ArrayList<>();
     
-    if (subject.getEducationType() != null && StringUtils.equals(subject.getEducationType().getCode(), educationTypeCode)) {
-      // Kyseessä soveltuvan koulutusasteen suoritus, etsitään edeltävät suoritukset
+    if ("MUU".equals(subject.getCode()) || (subject.getEducationType() != null && StringUtils.equals(subject.getEducationType().getCode(), educationTypeCode))) {
+      // Kyseessä soveltuvan koulutusasteen tai MUU-aineen suoritus, etsitään edeltävät suoritukset
 
       // Huom. Saman kurssin/modulin suoritukset etsitään tällä hetkellä saman Studentin tiedoista.
       // On mahdollista, että näitä pitäisi etsiä saman henkilön muidenkin opiskeluoikeuksien alta.
       
       // Kurssisuoritukset Studentin perusteella
       List<CourseAssessment> matchingCourseAssessments = courseAssessmentDAO.listByStudentAndSubjectAndCourseNumber(student, subject, courseNumber);
-      state = handleCreditList(matchingCourseAssessments, true, courseAssessment, state, previousEvaluations);
+      state = handleCreditList(matchingCourseAssessments, true, false, courseCredit, state, previousEvaluations);
 
       // Hyväksiluetut Studentin perusteella
       List<TransferCredit> matchingTransferCredits = transferCreditDAO.listByStudentAndSubjectAndCourseNumber(student, subject, courseNumber);
-      state = handleCreditList(matchingTransferCredits, false, courseAssessment, state, previousEvaluations);
+      state = handleCreditList(matchingTransferCredits, false, false, courseCredit, state, previousEvaluations);
       
       // Siirretyt suoritukset Studentin perusteella
       // Siirtosuoritukset käsitellään kuin ne olisivat hyväksilukuja, vaikka siirretty olisikin kurssisuoritus
       List<CreditLink> matchingCreditLinks = creditLinkDAO.listByStudentAndSubjectAndCourseNumber(student, subject, courseNumber);
       List<Credit> matchingCreditLinkCredits = matchingCreditLinks.stream().map(CreditLink::getCredit).toList();
-      state = handleCreditList(matchingCreditLinkCredits, false, courseAssessment, state, previousEvaluations);
+      state = handleCreditList(matchingCreditLinkCredits, false, true, courseCredit, state, previousEvaluations);
     }
     else {
       state = PerusopetusCreditState.REJECTED_EDUCATIONTYPE;
     }
     
     PerusopetusCredit credit = new PerusopetusCredit();
-    credit.setAssessorName(courseAssessment.getAssessor() != null ? courseAssessment.getAssessor().getFullName() : null);
+    credit.setAssessorName(courseCredit.getAssessor() != null ? courseCredit.getAssessor().getFullName() : null);
     credit.setCourseCode(courseCode);
     credit.setCourseLength(courseLength);
     credit.setCourseLengthSymbol(courseLengthSymbol);
-    credit.setCourseName(courseBase != null ? courseBase.getName() : null);
-    credit.setGradeName(courseAssessment.getGrade() != null ? courseAssessment.getGrade().getName() : null);
-    credit.setGradeDate(courseAssessment.getDate());
-    credit.setGradingScaleName((courseAssessment.getGrade() != null && courseAssessment.getGrade().getGradingScale() != null) ? courseAssessment.getGrade().getGradingScale().getName() : null);
-    credit.setGroupCourse(groupCourse);
+    credit.setCourseName(courseCredit.getCourseName());
+    credit.setGradeName(courseCredit.getGrade() != null ? courseCredit.getGrade().getName() : null);
+    credit.setGradeDate(courseCredit.getDate());
+    credit.setGradingScaleName((courseCredit.getGrade() != null && courseCredit.getGrade().getGradingScale() != null) ? courseCredit.getGrade().getGradingScale().getName() : null);
     credit.setPersonId(student.getPersonId());
     credit.setSchoolField((student.getSchool() != null && student.getSchool().getField() != null) ? student.getSchool().getField().getName() : null);
     credit.setSchoolName(student.getSchool() != null ? student.getSchool().getName() : null);
@@ -314,6 +330,7 @@ public class ReportRESTService extends AbstractRESTService {
     credit.setEvaluatedOutsideStudies(evaluatedOutsideStudies);
     credit.setKoskiFailure(koskiFailure);
     credit.setState(state);
+    credit.setType(creditType);
     
     if (previousEvaluations != null) {
       credit.setPreviousEvaluations(previousEvaluations);
@@ -321,4 +338,24 @@ public class ReportRESTService extends AbstractRESTService {
     
     return credit;
   }
+
+  private PerusopetusCredit restCreditForCourseAssessment(CourseAssessment courseAssessment, String educationTypeCode) {
+    CourseModule courseModule = courseAssessment.getCourseModule();
+    CourseBase courseBase = courseModule.getCourse();
+
+    boolean groupCourse;
+    if (courseBase instanceof Course && ((Course) courseBase).getTags() != null) {
+      Course course = (Course) courseBase;
+      groupCourse = course.getTags().stream().anyMatch(tag -> StringUtils.equals(tag.getText(), "ryhmäkurssi"));
+    }
+    else {
+      groupCourse = false;
+    }
+
+    PerusopetusCredit restCredit = restCredit(courseAssessment, educationTypeCode);
+    restCredit.setCourseId(courseBase.getId());
+    restCredit.setGroupCourse(groupCourse);
+    return restCredit;
+  }
+
 }


### PR DESCRIPTION
Perusopetuksen raportin säätöjä
- Lisätty VOS-hyväksiluvuille oma taulukko
- Lisätty arvosanariveille koodin päättelemä arvosanan tilatieto (hyväksytty/virhe/korotus/jne)
- Lisätty korotuksiin tieto siitä, minkä tyyppinen aiempi arvosana on ollut (kurssiarviointi/hyväksiluku/siirretty..)
- Lisätty summa VOS-hyväksiluvuista ja kurssisuorituksista
- Lisätty `CourseCredit` `Credit`:n ja `CourseAssessment`/`TransferCredit` väliin, jolla abstraktoitu tiettyyn kurssi(moduli)in kohdistuvia arviointeja
- Korjattu mahdollinen bugi, jonka mukaan arkistoitujen opiskelijoiden suorituksia saattoi listautua
- Korjattu !-continue-bugi, joka skippasi korotusten selvittämisen

Muuta
- Poistettu viewstudent:sta turha css-class

Closes #1815 